### PR TITLE
Add privacy policy page and routing

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,6 +27,7 @@ import Chat from "./Pages/Chat/Chat";
 import Blog from "./Pages/Blog/Blog";
 import BlogPost from "./Pages/Blog/BlogPost";
 import TermsPage from "./Pages/TermsPage/TermsPage";
+import PrivacyPolicy from "./Pages/PrivacyPolicy";
 
 const AppContent = () => {
   const location = useLocation();
@@ -67,6 +68,7 @@ const AppContent = () => {
         <Route path="/blog" element={<Blog />} />
         <Route path="/blog/:slug" element={<BlogPost />} />
         <Route path="/terms" element={<TermsPage />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route element={<PrivateRoutes />}>
           <Route path="/templates" element={<Templates />} />
           <Route path="/portal" element={<Portal />} />

--- a/client/src/Pages/PrivacyPolicy.jsx
+++ b/client/src/Pages/PrivacyPolicy.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import "./privacy-policy.styles.scss";
+
+const PrivacyPolicy = () => {
+  return (
+    <main className="privacy-policy">
+      <header className="privacy-policy-header">
+        <h1>Privacy Policy</h1>
+        <p className="effective-date">
+          <strong>Effective Date:</strong> October 19, 2025
+        </p>
+      </header>
+
+      <section className="privacy-policy-section">
+        <p>
+          At <strong>DevKofi.com</strong>, your privacy is important to us. This Privacy Policy explains how we
+          collect, use, and protect your information when you visit our website.
+        </p>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>1. Information We Collect</h2>
+        <ul className="privacy-list">
+          <li>
+            <strong>Personal Information</strong> — such as your name and email address if you contact us via a form or
+            subscribe to updates.
+          </li>
+          <li>
+            <strong>Non-Personal Information</strong> — such as browser type, device information, and pages visited,
+            collected automatically through analytics tools (e.g., Google Analytics).
+          </li>
+        </ul>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>2. How We Use Your Information</h2>
+        <ul className="privacy-list">
+          <li>Respond to inquiries or messages you send us.</li>
+          <li>Improve our website’s content and user experience.</li>
+          <li>Send occasional updates or newsletters (only if you’ve opted in).</li>
+        </ul>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>3. Cookies</h2>
+        <p>
+          Our website may use cookies to improve functionality and analyze site usage. You can choose to disable cookies
+          through your browser settings.
+        </p>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>4. Data Sharing and Security</h2>
+        <p>
+          We do <strong>not</strong> sell or rent your personal data to third parties.
+        </p>
+        <p>
+          We may share limited data with trusted service providers (e.g., email delivery or analytics tools) who assist
+          us in operating the site, under strict confidentiality. All reasonable measures are taken to keep your data
+          secure.
+        </p>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>5. Third-Party Links</h2>
+        <p>
+          Our website may contain links to external sites. We are not responsible for the privacy practices or content
+          of those sites.
+        </p>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>6. Your Rights</h2>
+        <ul className="privacy-list">
+          <li>Access or correct your personal information.</li>
+          <li>Unsubscribe from emails at any time.</li>
+          <li>Request deletion of your data by contacting us directly.</li>
+        </ul>
+      </section>
+
+      <section className="privacy-policy-section">
+        <h2>7. Contact Us</h2>
+        <p>
+          If you have any questions or privacy concerns, please contact:
+          <br />
+          <strong>Email:</strong> <a href="mailto:devkofi@gmail.com">devkofi@gmail.com</a>
+        </p>
+      </section>
+    </main>
+  );
+};
+
+export default PrivacyPolicy;

--- a/client/src/Pages/privacy-policy.styles.scss
+++ b/client/src/Pages/privacy-policy.styles.scss
@@ -1,0 +1,53 @@
+.privacy-policy {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem;
+  line-height: 1.7;
+  color: #111;
+}
+
+.privacy-policy-header {
+  margin-bottom: 1.25rem;
+}
+
+.effective-date {
+  margin-top: 0.25rem;
+  color: #555;
+}
+
+.privacy-policy-section {
+  margin-top: 1.5rem;
+}
+
+.privacy-policy h1 {
+  font-size: 2rem;
+  margin: 0;
+}
+
+.privacy-policy h2 {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.privacy-list {
+  padding-left: 1.25rem;
+  margin: 0.5rem 0 0 0;
+}
+
+.privacy-list li {
+  margin: 0.4rem 0;
+}
+
+@media (min-width: 768px) {
+  .privacy-policy {
+    padding: 3rem 1.5rem;
+  }
+
+  .privacy-policy h1 {
+    font-size: 2.25rem;
+  }
+
+  .privacy-policy h2 {
+    font-size: 1.35rem;
+  }
+}

--- a/client/src/__tests__/privacy-policy.page.test.jsx
+++ b/client/src/__tests__/privacy-policy.page.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import PrivacyPolicy from "../Pages/PrivacyPolicy";
+
+describe("PrivacyPolicy Page", () => {
+  it("renders heading and effective date", () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPolicy />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: /privacy policy/i })).toBeInTheDocument();
+    expect(screen.getByText(/Effective Date:/i)).toBeInTheDocument();
+  });
+
+  it("contains contact email link", () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPolicy />
+      </MemoryRouter>
+    );
+
+    const mailLink = screen.getByRole("link", { name: /devkofi@gmail.com/i });
+    expect(mailLink).toHaveAttribute("href", "mailto:devkofi@gmail.com");
+  });
+});

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -53,6 +53,7 @@ const Header = () => {
             <Link to="/chat">Chat</Link>
             <Link to="about-me">About</Link>
             {/* <Link to="/templates">Templates</Link> */}
+            <Link to="/privacy">Privacy</Link>
             <Link to="/contact">Contact</Link>
             {isDevEnvironment ? <Link to="/playground">Playground</Link> : null}
             {user ? (

--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const path = require("path");
 const createCors = require("./middleware/cors");
 
 // Middlewares
@@ -58,6 +59,19 @@ app.use("/api/pricing", pricingRoutes);
 app.use("/api/ask-mentor", askMentorRoutes);
 app.use("/api/chat", chatRoutes);
 app.use(["/health", "/api/health"], healthRoute);
+
+if (process.env.NODE_ENV === "production") {
+  const clientDist = path.join(__dirname, "..", "client", "dist");
+
+  app.use(express.static(clientDist));
+  app.get("*", (req, res, next) => {
+    if (req.path.startsWith("/api")) {
+      return next();
+    }
+
+    return res.sendFile(path.join(clientDist, "index.html"));
+  });
+}
 
 app.use(notFound);
 app.use(errorHandler);


### PR DESCRIPTION
## Summary
- add a dedicated Privacy Policy page with scoped SCSS styling and Vitest coverage
- register the /privacy route in the SPA router and expose it from the primary navigation
- configure the production Express server to serve index.html for unknown routes so SPA deep links keep working

## Testing
- npx vitest --run src/__tests__/privacy-policy.page.test.jsx
- npx vitest run src/__tests__/privacy-policy.page.test.jsx *(fails: existing ResizeObserver-dependent suites in ChatBox/Composer/MessageFlow/SelfHealing remain red)*

------
https://chatgpt.com/codex/tasks/task_e_68f4415cbea8833095b753068db5ac25