### PR TITLE
Implement authenticated settings page with hardened profile updates

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,6 +21,7 @@ import PricingPage from "./Pages/Pricing/Pricing";
 import Join from "./Pages/Join/Join";
 import Enterprise from "./Pages/Enterprise/Enterprise";
 import Onboarding from "./Pages/Onboarding/Onboarding";
+import Settings from "./Pages/Settings/Settings";
 
 import AdminRoute from "./components/AdminRoute/AdminRoute";
 import AdminUsers from "./Pages/Dashboard/AdminUsers/AdminUsers";
@@ -50,6 +51,7 @@ const App = () => {
         <Route element={<PrivateRoute />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/onboarding" element={<Onboarding />} />
+          <Route path="/settings" element={<Settings />} />
 
           <Route element={<AdminRoute />}>
             <Route path="/dashboard/admin/users" element={<AdminUsers />} />

--- a/client/src/Pages/Dashboard/StudentDashboard/StudentDashboard.jsx
+++ b/client/src/Pages/Dashboard/StudentDashboard/StudentDashboard.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import "./StudentDashboard.styles.scss";
 import { Briefcase, Sparkles, ShieldCheck, LifeBuoy } from "lucide-react";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 import useStudentDashboardSummaryQuery from "../../../hooks/useStudentDashboardSummaryQuery";
 import useMyAccessRequestsQuery from "../../../hooks/useMyAccessRequestsQuery";
 
@@ -76,6 +77,9 @@ const StudentDashboard = ({ user }) => {
             Welcome back, <span>{user?.firstName || "Student"}</span>
           </h1>
           <p>{computed.nextAction}</p>
+          <p>
+            <Link to="/settings">Edit profile settings</Link>
+          </p>
         </header>
 
         <main className="bento-grid">

--- a/client/src/Pages/Settings/Settings.jsx
+++ b/client/src/Pages/Settings/Settings.jsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import useProfileMeQuery from "../../hooks/useProfileMeQuery";
+import useUpdateProfileMutation from "../../hooks/useUpdateProfileMutation";
+import useOnboardingStatusQuery from "../../hooks/useOnboardingStatusQuery";
+import useMyEnrollmentsQuery from "../../hooks/useMyEnrollmentsQuery";
+import "./settings.styles.scss";
+
+const initialForm = {
+  timezone: "",
+  country: "",
+  currentRole: "",
+  skillLevel: "",
+  mernExperience: "",
+  aiExperience: "",
+  primaryGoal: "",
+  biggestBlocker: "",
+  githubUrl: "",
+  portfolioUrl: "",
+  linkedinUrl: "",
+  currentProjectSummary: "",
+  preferredStartTimeline: "",
+};
+
+const requiredFields = [
+  "currentRole",
+  "skillLevel",
+  "mernExperience",
+  "aiExperience",
+  "primaryGoal",
+  "biggestBlocker",
+  "currentProjectSummary",
+  "timezone",
+  "country",
+  "preferredStartTimeline",
+];
+
+const readinessFields = [...requiredFields];
+const urlFields = ["githubUrl", "portfolioUrl", "linkedinUrl"];
+
+const prettyFieldName = {
+  currentRole: "Current role",
+  skillLevel: "Skill level",
+  mernExperience: "MERN experience",
+  aiExperience: "AI experience",
+  primaryGoal: "Primary goal",
+  biggestBlocker: "Biggest blocker",
+  currentProjectSummary: "Current project summary",
+  timezone: "Timezone",
+  country: "Country",
+  preferredStartTimeline: "Preferred start timeline",
+};
+
+const sanitizeFieldValue = (value) => (typeof value === "string" ? value.trim() : "");
+
+const sanitizeForm = (form) => {
+  return Object.keys(initialForm).reduce((acc, key) => {
+    acc[key] = sanitizeFieldValue(form?.[key] || "");
+    return acc;
+  }, {});
+};
+
+const isValidOptionalUrl = (value) => {
+  const trimmed = sanitizeFieldValue(value);
+  if (!trimmed) return true;
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const getCompletionLabel = (percent) => {
+  if (percent >= 100) return "Complete";
+  if (percent >= 80) return "Nearly complete";
+  if (percent >= 40) return "In progress";
+  return "Incomplete";
+};
+
+const Settings = () => {
+  const { token } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+  const [form, setForm] = useState(initialForm);
+  const [initialSnapshot, setInitialSnapshot] = useState(initialForm);
+  const [errors, setErrors] = useState({});
+  const [feedback, setFeedback] = useState("");
+
+  const profileQuery = useProfileMeQuery(token);
+  const onboardingQuery = useOnboardingStatusQuery(token);
+  const enrollmentsQuery = useMyEnrollmentsQuery(token);
+  const updateMutation = useUpdateProfileMutation(token);
+
+  useEffect(() => {
+    if (!profileQuery.data?.profile) return;
+
+    const nextForm = sanitizeForm(profileQuery.data.profile);
+    setForm(nextForm);
+    setInitialSnapshot(nextForm);
+  }, [profileQuery.data]);
+
+  useEffect(() => {
+    const hasUnsaved = JSON.stringify(sanitizeForm(form)) !== JSON.stringify(sanitizeForm(initialSnapshot));
+    const onBeforeUnload = (event) => {
+      if (!hasUnsaved) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [form, initialSnapshot]);
+
+  const sanitizedForm = useMemo(() => sanitizeForm(form), [form]);
+  const sanitizedInitial = useMemo(() => sanitizeForm(initialSnapshot), [initialSnapshot]);
+
+  const isDirty = useMemo(
+    () => JSON.stringify(sanitizedForm) !== JSON.stringify(sanitizedInitial),
+    [sanitizedForm, sanitizedInitial],
+  );
+
+  const validationErrors = useMemo(() => {
+    const nextErrors = {};
+
+    requiredFields.forEach((field) => {
+      if (!sanitizedForm[field]) {
+        nextErrors[field] = "This field is required.";
+      }
+    });
+
+    urlFields.forEach((field) => {
+      if (!isValidOptionalUrl(sanitizedForm[field])) {
+        nextErrors[field] = "Enter a valid URL including http:// or https://";
+      }
+    });
+
+    return nextErrors;
+  }, [sanitizedForm]);
+
+  const hasValidationErrors = Object.keys(validationErrors).length > 0;
+
+  const changedPayload = useMemo(() => {
+    return Object.keys(sanitizedForm).reduce((acc, key) => {
+      if (sanitizedForm[key] !== sanitizedInitial[key]) {
+        acc[key] = sanitizedForm[key];
+      }
+      return acc;
+    }, {});
+  }, [sanitizedForm, sanitizedInitial]);
+
+  const completionPercent = Math.round(((onboardingQuery.data?.readinessScore || 0) / 10) * 100);
+  const completionLabel = getCompletionLabel(completionPercent);
+
+  const missingFields = readinessFields.filter((field) => !sanitizedForm[field]);
+
+  const enrollment = enrollmentsQuery.data?.enrollments?.[0] || null;
+  const plan = enrollment?.planSlug || profileQuery.data?.profile?.selectedPlan || "none";
+  const supportLevel = plan === "pro" ? "high-touch" : plan === "standard" ? "structured" : "not-set";
+
+  const accountName = [profileQuery.data?.user?.firstName, profileQuery.data?.user?.lastName]
+    .filter(Boolean)
+    .join(" ");
+
+  const onChangeField = (event) => {
+    const { name, value } = event.target;
+    setFeedback("");
+    setErrors((prev) => ({ ...prev, [name]: "" }));
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleReset = () => {
+    setForm(sanitizedInitial);
+    setErrors({});
+    setFeedback("");
+  };
+
+  const handleSave = async (event) => {
+    event.preventDefault();
+    setErrors(validationErrors);
+
+    if (!isDirty || hasValidationErrors || !Object.keys(changedPayload).length) {
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync(changedPayload);
+      const nextSnapshot = sanitizeForm({ ...sanitizedInitial, ...changedPayload });
+      setInitialSnapshot(nextSnapshot);
+      setForm(nextSnapshot);
+      setErrors({});
+      setFeedback("Profile saved successfully.");
+    } catch (error) {
+      setFeedback(error.message || "Unable to save profile.");
+    }
+  };
+
+  const handleLeaveSettings = () => {
+    if (isDirty) {
+      const shouldLeave = window.confirm("You have unsaved changes. Leave without saving?");
+      if (!shouldLeave) return;
+    }
+
+    navigate("/dashboard");
+  };
+
+  if (profileQuery.isLoading) {
+    return <div className="settings-page">Loading account settings...</div>;
+  }
+
+  if (profileQuery.isError) {
+    return (
+      <div className="settings-page settings-page--error">
+        <p>{profileQuery.error?.message || "Unable to load account settings."}</p>
+        <button onClick={() => profileQuery.refetch()} type="button">Retry</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-page">
+      <div className="settings-page__header">
+        <h1>Account Settings</h1>
+        <p>Manage your mentorship profile, links, and readiness</p>
+      </div>
+
+      <div className="settings-page__layout">
+        <form className="settings-form" onSubmit={handleSave}>
+          <section className="settings-card">
+            <h2>Engineering profile</h2>
+            <label>Current role<input name="currentRole" value={form.currentRole} onChange={onChangeField} /></label>
+            <label>Skill level
+              <select name="skillLevel" value={form.skillLevel} onChange={onChangeField}>
+                <option value="">Select skill level</option>
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Intermediate</option>
+                <option value="advanced">Advanced</option>
+              </select>
+            </label>
+            <label>MERN experience<textarea name="mernExperience" value={form.mernExperience} onChange={onChangeField} /></label>
+            <label>AI experience<textarea name="aiExperience" value={form.aiExperience} onChange={onChangeField} /></label>
+          </section>
+
+          <section className="settings-card">
+            <h2>Goals and context</h2>
+            <label>Primary goal<textarea name="primaryGoal" value={form.primaryGoal} onChange={onChangeField} /></label>
+            <label>Biggest blocker<textarea name="biggestBlocker" value={form.biggestBlocker} onChange={onChangeField} /></label>
+            <label>Current project summary<textarea name="currentProjectSummary" value={form.currentProjectSummary} onChange={onChangeField} /></label>
+            <label>Preferred start timeline
+              <select name="preferredStartTimeline" value={form.preferredStartTimeline} onChange={onChangeField}>
+                <option value="">Select timeline</option>
+                <option value="immediately">Immediately</option>
+                <option value="within_30_days">Within 30 days</option>
+                <option value="within_90_days">Within 90 days</option>
+                <option value="just_exploring">Just exploring</option>
+              </select>
+            </label>
+          </section>
+
+          <section className="settings-card">
+            <h2>Links and location</h2>
+            <label>GitHub URL<input name="githubUrl" value={form.githubUrl} onChange={onChangeField} /></label>
+            <label>Portfolio URL<input name="portfolioUrl" value={form.portfolioUrl} onChange={onChangeField} /></label>
+            <label>LinkedIn URL<input name="linkedinUrl" value={form.linkedinUrl} onChange={onChangeField} /></label>
+            <label>Timezone<input name="timezone" value={form.timezone} onChange={onChangeField} /></label>
+            <label>Country<input name="country" value={form.country} onChange={onChangeField} /></label>
+          </section>
+
+          <div className="settings-actions">
+            <button type="button" onClick={handleReset} disabled={updateMutation.isPending || !isDirty}>Reset</button>
+            <button type="submit" disabled={profileQuery.isLoading || updateMutation.isPending || !isDirty || hasValidationErrors}>
+              {updateMutation.isPending ? "Saving..." : "Save changes"}
+            </button>
+          </div>
+
+          {Object.keys(errors).length > 0 && (
+            <div className="settings-errors">
+              {Object.entries(errors).map(([key, message]) => (
+                <p key={key}>{prettyFieldName[key] || key}: {message}</p>
+              ))}
+            </div>
+          )}
+
+          {feedback ? <p className="settings-feedback">{feedback}</p> : null}
+        </form>
+
+        <aside className="settings-summary">
+          <section className="settings-card">
+            <h3>Account</h3>
+            <p><strong>Name:</strong> {accountName || "Not set"}</p>
+            <p><strong>Email:</strong> {profileQuery.data?.user?.email || "Not set"}</p>
+            <p><strong>Role:</strong> {profileQuery.data?.user?.role || "student"}</p>
+          </section>
+
+          <section className="settings-card">
+            <h3>Profile completeness</h3>
+            <p><strong>Completion:</strong> {completionPercent}%</p>
+            <p><strong>Readiness score:</strong> {onboardingQuery.data?.readinessScore || 0}/10</p>
+            <p><strong>Status:</strong> {completionLabel}</p>
+            <p><strong>Missing fields:</strong></p>
+            <ul>
+              {missingFields.length ? missingFields.map((field) => <li key={field}>{prettyFieldName[field]}</li>) : <li>All required fields completed.</li>}
+            </ul>
+          </section>
+
+          <section className="settings-card">
+            <h3>Plan & support summary</h3>
+            <p><strong>Plan:</strong> {plan}</p>
+            <p><strong>Enrollment status:</strong> {enrollment?.status || "none"}</p>
+            <p><strong>Application status:</strong> {enrollment?.applicationStatus || "draft"}</p>
+            <p><strong>Payment status:</strong> {enrollment?.paymentStatus || "not_required"}</p>
+            <p><strong>Support level:</strong> {supportLevel}</p>
+          </section>
+
+          <section className="settings-card">
+            <h3>Save state</h3>
+            <p>{isDirty ? "You have unsaved changes" : "All changes saved"}</p>
+            <button type="button" onClick={handleLeaveSettings}>Back to dashboard</button>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/client/src/Pages/Settings/settings.styles.scss
+++ b/client/src/Pages/Settings/settings.styles.scss
@@ -1,0 +1,83 @@
+.settings-page {
+  max-width: 1200px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+
+  &__header {
+    margin-bottom: 1.5rem;
+  }
+
+  &__layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+.settings-form,
+.settings-summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.settings-card {
+  background: #101727;
+  border: 1px solid #22314f;
+  border-radius: 12px;
+  padding: 1rem;
+
+  label {
+    display: grid;
+    gap: 0.4rem;
+    margin-top: 0.75rem;
+  }
+
+  input,
+  textarea,
+  select {
+    width: 100%;
+    border: 1px solid #2b3d61;
+    background: #0f1522;
+    color: #fff;
+    padding: 0.55rem 0.6rem;
+    border-radius: 8px;
+  }
+
+  textarea {
+    min-height: 80px;
+    resize: vertical;
+  }
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.75rem;
+
+  button {
+    border: none;
+    border-radius: 8px;
+    padding: 0.6rem 0.95rem;
+    cursor: pointer;
+  }
+}
+
+.settings-errors p {
+  color: #ffb5b5;
+  margin: 0.2rem 0;
+}
+
+.settings-feedback {
+  color: #90f5b8;
+}
+
+@media (min-width: 992px) {
+  .settings-page__layout {
+    grid-template-columns: 1.8fr 1fr;
+    align-items: start;
+  }
+
+  .settings-summary {
+    position: sticky;
+    top: 1rem;
+  }
+}

--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -46,6 +46,9 @@ const Header = () => {
               <Link to="/dashboard" className="nav-item">
                 Dashboard
               </Link>
+              <Link to="/settings" className="nav-item">
+                Settings
+              </Link>
               <button className="btn-logout" onClick={handleLogout}>
                 Logout
               </button>

--- a/client/src/components/SideNav/SideNav.jsx
+++ b/client/src/components/SideNav/SideNav.jsx
@@ -72,6 +72,17 @@ const SideNav = () => {
                 </NavLink>
               </li>
               <li className="nav-item">
+                <NavLink
+                  to="/settings"
+                  onClick={closeNav}
+                  className={({ isActive }) =>
+                    isActive ? "active-link" : "nav-link"
+                  }
+                >
+                  Settings
+                </NavLink>
+              </li>
+              <li className="nav-item">
                 <button className="logout-btn" onClick={handleLogout}>
                   Logout
                 </button>

--- a/client/src/hooks/useProfileMeQuery.js
+++ b/client/src/hooks/useProfileMeQuery.js
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+import { baseUrl } from "../constants/constants";
+
+const getStoredToken = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem("user") || "null");
+    return stored?.token || null;
+  } catch {
+    return null;
+  }
+};
+
+const fetchProfileMe = async (token) => {
+  const authToken = token || getStoredToken();
+
+  const res = await fetch(`${baseUrl}/api/profile/me`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data?.success === false) {
+    throw new Error(data?.error || "Failed to load profile.");
+  }
+
+  return {
+    user: data?.user || {},
+    profile: data?.profile || {},
+  };
+};
+
+const useProfileMeQuery = (token) => {
+  return useQuery({
+    queryKey: ["profile-me"],
+    queryFn: () => fetchProfileMe(token),
+    enabled: !!(token || getStoredToken()),
+  });
+};
+
+export default useProfileMeQuery;

--- a/client/src/hooks/useUpdateProfileMutation.js
+++ b/client/src/hooks/useUpdateProfileMutation.js
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { baseUrl } from "../constants/constants";
+
+const getStoredToken = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem("user") || "null");
+    return stored?.token || null;
+  } catch {
+    return null;
+  }
+};
+
+const patchProfile = async ({ payload, token }) => {
+  const authToken = token || getStoredToken();
+
+  const res = await fetch(`${baseUrl}/api/profile/me`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${authToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data?.success === false) {
+    throw new Error(data?.error || "Failed to update profile.");
+  }
+
+  return data;
+};
+
+const useUpdateProfileMutation = (token) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["update-profile"],
+    mutationFn: (payload) => patchProfile({ payload, token }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["profile-me"] }),
+        queryClient.invalidateQueries({ queryKey: ["onboarding-status"] }),
+        queryClient.invalidateQueries({ queryKey: ["student-dashboard-summary"] }),
+        queryClient.invalidateQueries({ queryKey: ["admin-users"] }),
+      ]);
+    },
+  });
+};
+
+export default useUpdateProfileMutation;

--- a/client/tests/settings.test.js
+++ b/client/tests/settings.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+
+describe("settings page wiring", () => {
+  it("registers private settings route and nav entries", () => {
+    const appContent = fs.readFileSync("src/App.jsx", "utf-8");
+    const headerContent = fs.readFileSync("src/components/Header/Header.jsx", "utf-8");
+    const sideNavContent = fs.readFileSync("src/components/SideNav/SideNav.jsx", "utf-8");
+
+    expect(appContent.includes('path="/settings"')).toBe(true);
+    expect(headerContent.includes('to="/settings"')).toBe(true);
+    expect(sideNavContent.includes('to="/settings"')).toBe(true);
+  });
+
+  it("settings page supports dirty state, validation, and summaries", () => {
+    const settingsContent = fs.readFileSync("src/Pages/Settings/Settings.jsx", "utf-8");
+
+    expect(settingsContent.includes("beforeunload")).toBe(true);
+    expect(settingsContent.includes("You have unsaved changes. Leave without saving?")).toBe(true);
+    expect(settingsContent.includes("validationErrors")).toBe(true);
+    expect(settingsContent.includes("changedPayload")).toBe(true);
+    expect(settingsContent.includes("Profile completeness")).toBe(true);
+    expect(settingsContent.includes("Plan & support summary")).toBe(true);
+  });
+
+  it("settings hooks target profile endpoints and cache invalidation", () => {
+    const profileHook = fs.readFileSync("src/hooks/useProfileMeQuery.js", "utf-8");
+    const updateHook = fs.readFileSync("src/hooks/useUpdateProfileMutation.js", "utf-8");
+
+    expect(profileHook.includes('/api/profile/me')).toBe(true);
+    expect(profileHook.includes('["profile-me"]')).toBe(true);
+
+    expect(updateHook.includes('/api/profile/me')).toBe(true);
+    expect(updateHook.includes('["onboarding-status"]')).toBe(true);
+    expect(updateHook.includes('["student-dashboard-summary"]')).toBe(true);
+    expect(updateHook.includes('["admin-users"]')).toBe(true);
+  });
+});

--- a/server/__test__/coreFlows.test.js
+++ b/server/__test__/coreFlows.test.js
@@ -80,6 +80,75 @@ describe("core mentorship flows", () => {
     expect(status.body.onboardingCompleted).toBe(true);
   });
 
+  it("profile me endpoints enforce editable-only updates", async () => {
+    const { token } = await registerAndLogin("profile-me");
+
+    const read = await request(app)
+      .get("/api/profile/me")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(read.statusCode).toBe(200);
+    expect(read.body.user).toMatchObject({
+      firstName: "Test",
+      email: "user.profile-me@example.com",
+    });
+    expect(read.body.profile).toBeDefined();
+
+    const statusBeforeValidPatch = await request(app)
+      .get("/api/onboarding/status")
+      .set("Authorization", `Bearer ${token}`);
+    expect(statusBeforeValidPatch.body.readinessScore).toBe(0);
+
+    const validPatch = await request(app)
+      .patch("/api/profile/me")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        currentRole: "Frontend Developer",
+        skillLevel: "intermediate",
+        mernExperience: "3 years",
+        aiExperience: "1 year",
+        primaryGoal: "Get mentorship",
+        biggestBlocker: "Execution speed",
+        currentProjectSummary: "Building a dashboard",
+        timezone: "UTC",
+        country: "Ghana",
+        preferredStartTimeline: "within_30_days",
+        githubUrl: "https://github.com/devkofi",
+      });
+
+    expect(validPatch.statusCode).toBe(200);
+    expect(validPatch.body.profile.currentRole).toBe("Frontend Developer");
+    expect(validPatch.body.profile.githubUrl).toBe("https://github.com/devkofi");
+
+    const statusAfterValidPatch = await request(app)
+      .get("/api/onboarding/status")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(statusAfterValidPatch.body.readinessScore).toBe(10);
+
+    const invalidPatch = await request(app)
+      .patch("/api/profile/me")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ onboardingCompleted: true });
+
+    expect(invalidPatch.statusCode).toBe(400);
+    expect(invalidPatch.body.error).toBe("No valid profile fields provided");
+
+    const invalidPatchStep = await request(app)
+      .patch("/api/profile/me")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ onboardingStep: 4 });
+    expect(invalidPatchStep.statusCode).toBe(400);
+    expect(invalidPatchStep.body.error).toBe("No valid profile fields provided");
+
+    const invalidPatchPlan = await request(app)
+      .patch("/api/profile/me")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ selectedPlan: "pro" });
+    expect(invalidPatchPlan.statusCode).toBe(400);
+    expect(invalidPatchPlan.body.error).toBe("No valid profile fields provided");
+  });
+
   it("enrollment application creation works and avoids duplicates", async () => {
     const { token } = await registerAndLogin("enroll");
 

--- a/server/controllers/profileController.js
+++ b/server/controllers/profileController.js
@@ -14,17 +14,34 @@ const editableFields = [
   "linkedinUrl",
   "currentProjectSummary",
   "preferredStartTimeline",
-  "onboardingCompleted",
-  "onboardingStep",
-  "selectedPlan",
-  "supportPreference",
 ];
+
+const skillLevelValues = ["beginner", "intermediate", "advanced"];
+const startTimelineValues = ["immediately", "within_30_days", "within_90_days", "just_exploring"];
+const optionalUrlFields = ["githubUrl", "portfolioUrl", "linkedinUrl"];
 
 const hasValue = (v) => typeof v === "string" ? v.trim().length > 0 : Boolean(v);
 
+const sanitizeString = (value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return value.trim();
+};
+
+const isValidUrl = (urlValue) => {
+  try {
+    const parsed = new URL(urlValue);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 const getProfileMe = async (req, res) => {
   try {
-    const user = await User.findById(req.userId).select("firstName lastName email profile").lean();
+    const user = await User.findById(req.userId).select("firstName lastName email role profile").lean();
     if (!user) {
       return res.status(404).json({ success: false, error: "User not found" });
     }
@@ -41,22 +58,44 @@ const patchProfileMe = async (req, res) => {
     const updates = {};
 
     for (const field of editableFields) {
-      if (Object.prototype.hasOwnProperty.call(body, field)) {
-        updates[`profile.${field}`] = body[field];
+      if (!Object.prototype.hasOwnProperty.call(body, field)) {
+        continue;
       }
+
+      const rawValue = body[field];
+      if (typeof rawValue !== "string") {
+        return res.status(400).json({ success: false, error: `${field} must be a string` });
+      }
+      const value = sanitizeString(rawValue);
+
+      if (optionalUrlFields.includes(field)) {
+        if (value !== "" && !isValidUrl(value)) {
+          return res.status(400).json({ success: false, error: `${field} must be a valid URL` });
+        }
+      }
+
+      if (field === "skillLevel" && value && !skillLevelValues.includes(value)) {
+        return res.status(400).json({ success: false, error: "skillLevel is invalid" });
+      }
+
+      if (field === "preferredStartTimeline" && value && !startTimelineValues.includes(value)) {
+        return res.status(400).json({ success: false, error: "preferredStartTimeline is invalid" });
+      }
+
+      updates[`profile.${field}`] = value;
     }
 
     if (!Object.keys(updates).length) {
-      return res.status(400).json({ success: false, error: "No profile fields provided" });
+      return res.status(400).json({ success: false, error: "No valid profile fields provided" });
     }
 
     const user = await User.findByIdAndUpdate(
       req.userId,
       { $set: updates },
       { new: true },
-    ).select("firstName lastName email profile").lean();
+    ).select("firstName lastName email role profile").lean();
 
-    return res.json({ success: true, profile: user?.profile || {} });
+    return res.json({ success: true, message: "Profile updated successfully", profile: user?.profile || {} });
   } catch (error) {
     return res.status(400).json({ success: false, error: error.message });
   }


### PR DESCRIPTION
### Motivation

- Provide a production-ready `/settings` UX that lets authenticated users view and edit safe profile fields while preventing system-owned state drift. 
- Harden the backend `PATCH /api/profile/me` contract so only user-controlled profile attributes are writable and validated.

### Description

- Server: restricted editable keys in `server/controllers/profileController.js`, added string trimming, URL validation for link fields, and enum checks for `skillLevel` and `preferredStartTimeline`, and improved the empty-payload error to `No valid profile fields provided`.
- Client hooks: added `client/src/hooks/useProfileMeQuery.js` and `client/src/hooks/useUpdateProfileMutation.js` to encapsulate `GET /api/profile/me` and `PATCH /api/profile/me` with React Query integration and cache invalidation of `["profile-me"]`, `["onboarding-status"]`, `["student-dashboard-summary"]`, and `["admin-users"]`.
- Routing & navigation: registered a private `/settings` route and added Settings links to the top `Header` and `SideNav`, plus a CTA in the student dashboard.
- Settings page: new `client/src/Pages/Settings/Settings.jsx` and styles `settings.styles.scss` implementing form hydration from profile, sanitized snapshots, dirty-state detection, required and URL validation, diff-only save payloads, reset behavior, `beforeunload` protection, in-page leave confirmation, and account/completeness/plan-support summary cards.
- Tests: added backend test coverage for allowed/forbidden profile patch behavior (`server/__test__/coreFlows.test.js`) and frontend wiring tests `client/tests/settings.test.js` that assert route/nav/hooks/page wiring.

### Testing

- Frontend unit tests: ran `npm run test --prefix client -- --run tests/auth.test.js tests/settings.test.js`, all client tests passed (`2 files, 7 tests` ✅).
- Frontend build: ran `npm run build --prefix client` and the production build completed successfully ✅.
- Backend tests: attempted `npx jest server/__test__/coreFlows.test.js --runInBand` but the run failed in this environment due to missing/remote MongoDB DNS (connection error: `querySrv ENOTFOUND _mongodb._tcp.cluster0.lj8un.mongodb.net`), so server tests could not complete in CI here ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb462fbe588330ace32c84cba14c09)