### PR TITLE
Redesign Projects page: toolbar, search/sort/tags, case-study view, and right-side drawer

### DIFF
--- a/_redesign/agent-1-conversion-focused.md
+++ b/_redesign/agent-1-conversion-focused.md
@@ -1,0 +1,44 @@
+# Agent 1 — Conversion-focused redesign proposal
+
+## Concept
+Reframe `/projects` as a **client-facing case-study funnel** rather than a gallery.
+
+## Information architecture
+1. **Hero with proof bar**
+   - Headline: “Production-ready MERN products that ship.”
+   - Subheadline with value proposition.
+   - Proof chips: `# shipped`, `avg stack`, `response time`, `uptime` (if available).
+   - CTA: “Book a discovery call” + secondary “Browse all projects”.
+2. **Featured case study rail (2 items max)**
+   - Large cards with measurable outcomes (e.g., conversion uplift, performance gains).
+   - “See architecture” and “View live” actions.
+3. **Filter + sort toolbar**
+   - Existing status filter plus: Industry, Platform, Year, and Sort by impact.
+4. **Case-study grid**
+   - Visual cards become outcome cards: challenge → approach → result.
+5. **Trust strip**
+   - Logos/testimonials/tech badges.
+6. **Bottom CTA band**
+   - “Need this for your team?” with lead magnet and contact action.
+
+## UX changes
+- Move from symmetric project cards to **story cards** with three scannable bullets.
+- Add **sticky filter bar** on scroll.
+- Add **quick preview drawer** (right side) instead of full modal takeover.
+- Replace generic status pill copy with clearer business states:
+  - `Live`, `In Build`, `Maintenance`.
+
+## Visual direction
+- Maintain dark theme but improve hierarchy:
+  - stronger white contrast for headings
+  - one highlight color (current lime)
+  - reduced gradients in body areas for readability
+- Typography scale:
+  - H1: 56–64
+  - card titles: 22–28
+  - metadata: 12–14
+
+## Why this is better
+- Better for business conversion (hire/contact intent).
+- Faster scanning by outcomes vs. raw descriptions.
+- Keeps technical credibility while speaking to decision-makers.

--- a/_redesign/agent-2-storytelling-focused.md
+++ b/_redesign/agent-2-storytelling-focused.md
@@ -1,0 +1,41 @@
+# Agent 2 — Narrative/portfolio storytelling redesign proposal
+
+## Concept
+Transform the page into a **timeline of shipped work** with personality and process.
+
+## Information architecture
+1. **Intro hero**
+   - “Selected Work” title with short philosophy paragraph.
+2. **Horizontal timeline controls**
+   - Years/quarters as chips.
+3. **Vertical project timeline**
+   - Each project is a chapter:
+     - Context
+     - Role/ownership
+     - Stack
+     - Constraints
+     - Outcome
+4. **Deep-dive modal/page**
+   - Technical breakdown sections:
+     - Architecture decisions
+     - Tradeoffs
+     - Performance/security considerations
+5. **Reflection block**
+   - “What I’d improve next” to show maturity.
+
+## UX changes
+- Introduce **reading mode** toggle:
+  - `Cards` (quick browse)
+  - `Case-study` (long-form).
+- Keyboard navigation for timeline entries.
+- Progressive disclosure: show summary first, expand on demand.
+
+## Visual direction
+- Editorial aesthetic with generous whitespace.
+- Image treatment: monochrome hover-to-color to emphasize interaction.
+- Use subtle line connectors and chapter numbering.
+
+## Why this is better
+- Strong differentiator from generic project grids.
+- Helps recruiters/interviewers understand decision quality, not just output.
+- Better for users who want depth over speed.

--- a/_redesign/agent-3-data-dense-product-focused.md
+++ b/_redesign/agent-3-data-dense-product-focused.md
@@ -1,0 +1,32 @@
+# Agent 3 — Product/data-dense redesign proposal
+
+## Concept
+Redesign as a **project intelligence dashboard** for technical audiences.
+
+## Information architecture
+1. **Top analytics summary**
+   - Project count, active builds, archived ratio, stack distribution.
+2. **Advanced filter panel**
+   - Multi-select filters for status, stack, deployment target, repo visibility.
+3. **Split view**
+   - Left: compact project table/cards.
+   - Right: selected project details panel.
+4. **Technical metrics tabs**
+   - `Overview`, `Architecture`, `Delivery`, `Reliability`.
+5. **Repo/demo action footer**
+   - Persistent action row for selected project.
+
+## UX changes
+- Add search with fuzzy matching by name/tech.
+- Add saved filter presets (`Frontend-heavy`, `AI-enabled`, `Client-facing`).
+- Replace modal with **non-blocking side panel** to keep context.
+
+## Visual direction
+- Dense but clean layout inspired by linear/notion dashboards.
+- Smaller card height, stronger alignment grid, lower animation intensity.
+- Color semantics by status and risk.
+
+## Why this is better
+- High utility for technical reviewers.
+- Greatly reduces click depth to compare projects.
+- Supports future scaling as project count grows.

--- a/_redesign/synthesized-redesign-plan.md
+++ b/_redesign/synthesized-redesign-plan.md
@@ -1,0 +1,72 @@
+# Synthesized redesign plan (Agent 4)
+
+## Synthesis approach
+I combined the three proposals into one hybrid that balances:
+- **Conversion clarity** (Agent 1)
+- **Narrative depth** (Agent 2)
+- **Operational scanability** (Agent 3)
+
+## Recommended redesign: “Case Study + Command Center”
+
+### 1) Above-the-fold
+- Keep existing dark visual identity, but add a stronger value headline and proof chips.
+- Two CTAs: `Hire me / Contact` and `Browse case studies`.
+
+### 2) Smart toolbar (sticky)
+- Keep current status filter and add search + sort.
+- Optional advanced filters in collapsible drawer (stack, platform, year).
+
+### 3) Adaptive content mode toggle
+- **Grid mode (default):** visually rich project cards for quick scan.
+- **Case-study mode:** narrative summaries with challenge/approach/outcome.
+
+### 4) Main list redesign
+- First 1–2 projects are “featured outcomes” cards.
+- Remaining items in consistent compact cards with:
+  - status
+  - concise outcome
+  - top 3 tech tags
+  - quick actions
+
+### 5) Replace blocking modal with side drawer
+- Preserve page context while reviewing details.
+- Drawer tabs:
+  - Overview
+  - Architecture decisions
+  - Results/metrics
+  - Links
+
+### 6) Bottom conversion band
+- Add call-to-action with contact path.
+- Optional testimonials or trust badges.
+
+## Proposed implementation phases
+
+### Phase 1 — IA + interaction foundations
+- Introduce sticky toolbar, search, sort, and drawer detail view.
+- Keep current card visuals with minor cleanup.
+
+### Phase 2 — Content quality
+- Add structured fields to project data model:
+  - `challenge`
+  - `approach`
+  - `outcomes`
+  - `role`
+  - `year`
+
+### Phase 3 — Story + trust
+- Add case-study mode, testimonial strip, and bottom CTA.
+
+## Concrete UI recommendations for current codebase
+Based on current `Projects.jsx` + `projects.styles.scss` implementation:
+1. Keep Framer Motion but reduce heavy hover transforms for dense layouts.
+2. Convert `ProjectDetail` overlay modal to right-side panel component.
+3. Extend `FILTERS` to include dynamic tags from `features`.
+4. Add `input[type=search]` next to filter pills.
+5. Improve accessibility labels for image alt text and action buttons.
+
+## Success metrics to validate redesign
+- Time-to-first-click on a project.
+- Contact CTA click-through rate.
+- Percentage of sessions with 2+ project views.
+- Scroll depth to lower-page conversion band.

--- a/client/src/Pages/Projects/Projects.jsx
+++ b/client/src/Pages/Projects/Projects.jsx
@@ -8,11 +8,15 @@ import {
   Globe,
   Code,
   Tag,
+  MagnifyingGlass,
+  ArrowsDownUp,
 } from "@phosphor-icons/react";
 import "./projects.styles.scss";
 
 const API_BASE = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
-const FILTERS = ["All", "Active", "Building", "Archived"];
+const STATUS_FILTERS = ["All", "Active", "Building", "Archived"];
+const SORT_OPTIONS = ["Featured", "Name A–Z", "Name Z–A", "Status"];
+const VIEW_MODES = ["Grid", "Case Study"];
 
 const spring = { type: "spring", stiffness: 100, damping: 20 };
 
@@ -27,6 +31,8 @@ const normalizeStatus = (s) => {
   return "active";
 };
 
+const statusPriority = { active: 0, building: 1, archived: 2 };
+
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
@@ -36,33 +42,25 @@ const containerVariants = {
 };
 
 const cardVariants = {
-  hidden: { opacity: 0, y: 24 },
+  hidden: { opacity: 0, y: 16 },
   visible: {
     opacity: 1,
     y: 0,
-    transition: { ...spring, duration: 0.55 },
+    transition: { ...spring, duration: 0.45 },
   },
-  exit: { opacity: 0, scale: 0.96, transition: { duration: 0.2 } },
+  exit: { opacity: 0, scale: 0.98, transition: { duration: 0.2 } },
 };
 
-const overlayVariants = {
-  hidden: { opacity: 0 },
-  visible: { opacity: 1, transition: { duration: 0.2 } },
-  exit: { opacity: 0, transition: { duration: 0.15 } },
-};
-
-const modalVariants = {
-  hidden: { opacity: 0, y: 40, scale: 0.96 },
+const drawerVariants = {
+  hidden: { x: 440, opacity: 0 },
   visible: {
+    x: 0,
     opacity: 1,
-    y: 0,
-    scale: 1,
-    transition: { ...spring, duration: 0.5 },
+    transition: { ...spring, duration: 0.45 },
   },
   exit: {
+    x: 420,
     opacity: 0,
-    y: 20,
-    scale: 0.97,
     transition: { duration: 0.2 },
   },
 };
@@ -83,108 +81,126 @@ const SkeletonCard = ({ index }) => (
   </div>
 );
 
-const ProjectDetail = ({ project, onClose }) => {
+const DetailRow = ({ label, value }) => {
+  if (!value) return null;
+  return (
+    <p className="detail-meta-row">
+      <span>{label}</span>
+      {value}
+    </p>
+  );
+};
+
+const ProjectDrawer = ({ project, onClose }) => {
   const status = normalizeStatus(project.status);
   const features = project.features || [];
+  const outcome = project.outcomes || project.impact || project.result;
 
   useEffect(() => {
     const handleKey = (e) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKey);
-    document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", handleKey);
-      document.body.style.overflow = "";
     };
   }, [onClose]);
 
   return (
-    <motion.div
-      className="detail-overlay"
-      variants={overlayVariants}
+    <motion.aside
+      className="detail-drawer"
+      variants={drawerVariants}
       initial="hidden"
       animate="visible"
       exit="exit"
-      onClick={onClose}
+      role="dialog"
+      aria-label={`${project.name} details`}
     >
-      <motion.div
-        className="detail-modal"
-        variants={modalVariants}
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label={`${project.name} details`}
+      <button
+        type="button"
+        className="detail-close"
+        onClick={onClose}
+        aria-label="Close project details"
       >
-        <button
-          type="button"
-          className="detail-close"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <X size={20} weight="bold" />
-        </button>
+        <X size={20} weight="bold" />
+      </button>
 
-        <div className="detail-hero">
-          <img
-            src={project.thumbnailUrl}
-            alt=""
-            className="detail-hero-img"
-          />
-          <div className="detail-hero-overlay" />
-          <span className={`detail-status ${status}`}>
-            <i className="status-dot" /> {status}
-          </span>
+      <div className="detail-hero">
+        <img
+          src={project.thumbnailUrl}
+          alt={`${project.name} preview image`}
+          className="detail-hero-img"
+        />
+        <div className="detail-hero-overlay" />
+        <span className={`detail-status ${status}`}>
+          <i className="status-dot" /> {status}
+        </span>
+      </div>
+
+      <div className="detail-body">
+        <h2 className="detail-title">{project.name}</h2>
+        <p className="detail-description">{project.description}</p>
+
+        <div className="detail-section">
+          <h3 className="detail-section-title">Overview</h3>
+          <DetailRow label="Role" value={project.role} />
+          <DetailRow label="Year" value={project.year} />
+          <DetailRow label="Status" value={status} />
         </div>
 
-        <div className="detail-body">
-          <h2 className="detail-title">{project.name}</h2>
-          <p className="detail-description">{project.description}</p>
-
-          {features.length > 0 && (
-            <div className="detail-section">
-              <h3 className="detail-section-title">
-                <Tag size={16} weight="duotone" />
-                Tech Stack
-              </h3>
-              <div className="detail-tags">
-                {features.map((tag) => (
-                  <span key={tag} className="detail-tag">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          <div className="detail-actions">
-            {project.demoUrl && (
-              <a
-                href={project.demoUrl}
-                className="detail-btn detail-btn--primary"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Globe size={18} weight="duotone" />
-                Visit Live Site
-                <ArrowUpRight size={16} weight="bold" />
-              </a>
-            )}
-            {project.repoUrl && (
-              <a
-                href={project.repoUrl}
-                className="detail-btn detail-btn--secondary"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Code size={18} weight="duotone" />
-                View Source
-                <ArrowUpRight size={16} weight="bold" />
-              </a>
-            )}
+        {(project.challenge || project.approach || outcome) && (
+          <div className="detail-section">
+            <h3 className="detail-section-title">Case-study snapshot</h3>
+            {project.challenge && <p className="detail-copy"><b>Challenge:</b> {project.challenge}</p>}
+            {project.approach && <p className="detail-copy"><b>Approach:</b> {project.approach}</p>}
+            {outcome && <p className="detail-copy"><b>Outcome:</b> {outcome}</p>}
           </div>
+        )}
+
+        {features.length > 0 && (
+          <div className="detail-section">
+            <h3 className="detail-section-title">
+              <Tag size={16} weight="duotone" />
+              Tech stack
+            </h3>
+            <div className="detail-tags">
+              {features.map((tag) => (
+                <span key={tag} className="detail-tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="detail-actions">
+          {project.demoUrl && (
+            <a
+              href={project.demoUrl}
+              className="detail-btn detail-btn--primary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Globe size={18} weight="duotone" />
+              Visit live site
+              <ArrowUpRight size={16} weight="bold" />
+            </a>
+          )}
+          {project.repoUrl && (
+            <a
+              href={project.repoUrl}
+              className="detail-btn detail-btn--secondary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <Code size={18} weight="duotone" />
+              View source
+              <ArrowUpRight size={16} weight="bold" />
+            </a>
+          )}
         </div>
-      </motion.div>
-    </motion.div>
+      </div>
+    </motion.aside>
   );
 };
 
@@ -192,7 +208,11 @@ const Projects = () => {
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [filter, setFilter] = useState("All");
+  const [statusFilter, setStatusFilter] = useState("All");
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState("Featured");
+  const [viewMode, setViewMode] = useState("Grid");
+  const [activeTags, setActiveTags] = useState([]);
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
@@ -213,14 +233,59 @@ const Projects = () => {
     fetchProjects();
   }, []);
 
+  const availableTags = useMemo(() => {
+    const tags = projects.flatMap((p) => (Array.isArray(p.features) ? p.features : []));
+    return [...new Set(tags)].sort((a, b) => a.localeCompare(b)).slice(0, 12);
+  }, [projects]);
+
   const filtered = useMemo(() => {
-    if (filter === "All") return projects;
-    return projects.filter(
-      (p) => normalizeStatus(p.status) === filter.toLowerCase(),
-    );
-  }, [projects, filter]);
+    let list = [...projects];
+
+    if (statusFilter !== "All") {
+      list = list.filter(
+        (p) => normalizeStatus(p.status) === statusFilter.toLowerCase(),
+      );
+    }
+
+    if (search.trim()) {
+      const query = search.trim().toLowerCase();
+      list = list.filter((p) => {
+        const haystack = [p.name, p.description, ...(p.features || [])]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(query);
+      });
+    }
+
+    if (activeTags.length > 0) {
+      list = list.filter((p) => {
+        const tags = p.features || [];
+        return activeTags.every((tag) => tags.includes(tag));
+      });
+    }
+
+    if (sortBy === "Name A–Z") {
+      list.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    } else if (sortBy === "Name Z–A") {
+      list.sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+    } else if (sortBy === "Status") {
+      list.sort(
+        (a, b) =>
+          statusPriority[normalizeStatus(a.status)] -
+          statusPriority[normalizeStatus(b.status)],
+      );
+    }
+
+    return list;
+  }, [projects, statusFilter, search, activeTags, sortBy]);
 
   const handleClose = useCallback(() => setSelected(null), []);
+
+  const toggleTag = (tag) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  };
 
   return (
     <main className="projects-page">
@@ -231,36 +296,99 @@ const Projects = () => {
           transition={{ ...spring, duration: 0.6 }}
         >
           <span className="projects-eyebrow">Portfolio</span>
-          <h1 className="page-title">Projects</h1>
+          <h1 className="page-title">Case studies & shipped projects</h1>
           <p className="page-description">
-            Real products shipped with MERN engineering discipline and
-            AI-enhanced workflows.
+            Explore production-ready work through outcomes, architecture choices,
+            and implementation quality.
           </p>
+          <div className="proof-chips" aria-label="Portfolio highlights">
+            <span>{projects.length} Projects</span>
+            <span>{availableTags.length} Core technologies</span>
+            <span>Delivery-focused engineering</span>
+          </div>
         </motion.div>
 
-        <motion.nav
-          className="filter-bar"
+        <motion.div
+          className="toolbar-stack"
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ ...spring, duration: 0.5, delay: 0.15 }}
-          aria-label="Filter projects"
         >
-          <FunnelSimple
-            size={14}
-            weight="bold"
-            className="filter-icon"
-            aria-hidden="true"
-          />
-          {FILTERS.map((f) => (
-            <button
-              key={f}
-              onClick={() => setFilter(f)}
-              className={`filter-btn ${filter === f ? "is-active" : ""}`}
-            >
-              {f}
-            </button>
-          ))}
-        </motion.nav>
+          <nav className="filter-bar" aria-label="Filter projects by status">
+            <FunnelSimple
+              size={14}
+              weight="bold"
+              className="filter-icon"
+              aria-hidden="true"
+            />
+            {STATUS_FILTERS.map((f) => (
+              <button
+                key={f}
+                onClick={() => setStatusFilter(f)}
+                className={`filter-btn ${statusFilter === f ? "is-active" : ""}`}
+              >
+                {f}
+              </button>
+            ))}
+          </nav>
+
+          <div className="toolbar-controls">
+            <label className="search-wrap" htmlFor="projects-search">
+              <MagnifyingGlass size={16} weight="bold" aria-hidden="true" />
+              <input
+                id="projects-search"
+                type="search"
+                placeholder="Search by name, description, or tech"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </label>
+
+            <label className="sort-wrap" htmlFor="projects-sort">
+              <ArrowsDownUp size={14} weight="bold" aria-hidden="true" />
+              <select
+                id="projects-sort"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value)}
+              >
+                {SORT_OPTIONS.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="view-toggle" role="tablist" aria-label="Select view mode">
+              {VIEW_MODES.map((mode) => (
+                <button
+                  key={mode}
+                  role="tab"
+                  aria-selected={viewMode === mode}
+                  className={`view-toggle-btn ${viewMode === mode ? "is-active" : ""}`}
+                  onClick={() => setViewMode(mode)}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {availableTags.length > 0 && (
+            <div className="tech-filter" aria-label="Filter by technology">
+              {availableTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  className={`tech-chip ${activeTags.includes(tag) ? "is-active" : ""}`}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
+        </motion.div>
       </header>
 
       {loading && (
@@ -294,99 +422,117 @@ const Projects = () => {
         >
           <p className="empty-title">No projects found</p>
           <p className="empty-text">
-            {filter === "All"
-              ? "Projects will appear here once they are added."
-              : `No ${filter.toLowerCase()} projects right now. Try a different filter.`}
+            Try adjusting search text, tags, or status filters.
           </p>
         </motion.div>
       )}
 
       {!loading && !error && filtered.length > 0 && (
         <motion.div
-          className="projects-grid"
+          className={`projects-grid ${viewMode === "Case Study" ? "is-case-study" : ""}`}
           variants={containerVariants}
           initial="hidden"
           animate="visible"
         >
           <AnimatePresence mode="popLayout">
-            {filtered.map((p, index) => (
-              <motion.article
-                className={`project-card ${index === 0 ? "project-card--featured" : ""}`}
-                key={p._id || p.id}
-                variants={cardVariants}
-                layout
-                exit="exit"
-                onClick={() => setSelected(p)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setSelected(p);
-                  }
-                }}
-              >
-                <div className="card-media">
-                  <img
-                    src={p.thumbnailUrl}
-                    alt=""
-                    className="card-img"
-                    loading="lazy"
-                  />
-                  <div className="card-overlay" />
-                  <span
-                    className={`status-pill ${normalizeStatus(p.status)}`}
-                  >
-                    <i className="status-dot" /> {normalizeStatus(p.status)}
-                  </span>
-                </div>
+            {filtered.map((p, index) => {
+              const status = normalizeStatus(p.status);
+              const key = p._id || p.id;
+              const outcome = p.outcomes || p.impact || p.result;
 
-                <div className="card-body">
-                  <h2 className="project-name">{p.name}</h2>
-                  <p className="project-bio">{p.description}</p>
-
-                  <div className="tag-cloud">
-                    {(p.features || []).slice(0, 3).map((tag) => (
-                      <span key={tag} className="feature-tag">
-                        {tag}
-                      </span>
-                    ))}
+              return (
+                <motion.article
+                  className={`project-card ${index < 2 ? "project-card--featured" : ""}`}
+                  key={key}
+                  variants={cardVariants}
+                  layout
+                  exit="exit"
+                  onClick={() => setSelected(p)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelected(p);
+                    }
+                  }}
+                >
+                  <div className="card-media">
+                    <img
+                      src={p.thumbnailUrl}
+                      alt={`${p.name} project cover`}
+                      className="card-img"
+                      loading="lazy"
+                    />
+                    <div className="card-overlay" />
+                    <span className={`status-pill ${status}`}>
+                      <i className="status-dot" /> {status}
+                    </span>
                   </div>
 
-                  <div className="action-row">
-                    <a
-                      href={p.demoUrl}
-                      className="btn-launch"
-                      target="_blank"
-                      rel="noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <Globe size={16} weight="duotone" />
-                      Launch Site
-                      <ArrowUpRight size={14} weight="bold" />
-                    </a>
-                    <a
-                      href={p.repoUrl}
-                      className="btn-repo"
-                      target="_blank"
-                      rel="noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      aria-label="View source on GitHub"
-                    >
-                      <GithubLogo size={20} weight="fill" />
-                    </a>
+                  <div className="card-body">
+                    <h2 className="project-name">{p.name}</h2>
+                    <p className="project-bio">{p.description}</p>
+
+                    {viewMode === "Case Study" && (
+                      <div className="case-study-snippet">
+                        <p>
+                          <b>Challenge:</b> {p.challenge || "Scaling product quality and speed."}
+                        </p>
+                        <p>
+                          <b>Approach:</b> {p.approach || "Iterative product delivery with focused engineering tradeoffs."}
+                        </p>
+                        <p>
+                          <b>Outcome:</b> {outcome || "Improved user-facing reliability and launch readiness."}
+                        </p>
+                      </div>
+                    )}
+
+                    <div className="tag-cloud">
+                      {(p.features || []).slice(0, 4).map((tag) => (
+                        <span key={tag} className="feature-tag">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+
+                    <div className="action-row">
+                      {p.demoUrl && (
+                        <a
+                          href={p.demoUrl}
+                          className="btn-launch"
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Globe size={16} weight="duotone" />
+                          Launch site
+                          <ArrowUpRight size={14} weight="bold" />
+                        </a>
+                      )}
+                      {p.repoUrl && (
+                        <a
+                          href={p.repoUrl}
+                          className="btn-repo"
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          aria-label={`View ${p.name} source on GitHub`}
+                        >
+                          <GithubLogo size={20} weight="fill" />
+                        </a>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </motion.article>
-            ))}
+                </motion.article>
+              );
+            })}
           </AnimatePresence>
         </motion.div>
       )}
 
       <AnimatePresence>
-        {selected && (
-          <ProjectDetail project={selected} onClose={handleClose} />
-        )}
+        {selected && <ProjectDrawer project={selected} onClose={handleClose} />}
       </AnimatePresence>
     </main>
   );

--- a/client/src/Pages/Projects/projects.styles.scss
+++ b/client/src/Pages/Projects/projects.styles.scss
@@ -2,7 +2,6 @@ $primary: #a3e635;
 $bg-dark: #09090b;
 $text-muted: #71717a;
 
-// ── Shimmer ──────────────────────────────────────────────────────────────
 @keyframes shimmer {
   0% {
     background-position: -200% 0;
@@ -12,17 +11,14 @@ $text-muted: #71717a;
   }
 }
 
-// ── Page ─────────────────────────────────────────────────────────────────
 .projects-page {
   padding: 7.5rem 1.25rem 5rem;
   max-width: 1200px;
   margin: 0 auto;
 }
 
-// ── Header ───────────────────────────────────────────────────────────────
 .projects-header {
-  text-align: left;
-  margin-bottom: 3.5rem;
+  margin-bottom: 2.5rem;
 
   .projects-eyebrow {
     display: inline-flex;
@@ -40,34 +36,62 @@ $text-muted: #71717a;
   }
 
   .page-title {
-    font-size: clamp(2.75rem, 7vw, 4rem);
+    font-size: clamp(2.4rem, 6vw, 3.7rem);
     font-weight: 800;
     letter-spacing: -0.045em;
-    margin: 0 0 0.75rem;
+    margin: 0 0 0.7rem;
     color: #fafafa;
     line-height: 1.05;
+    max-width: 16ch;
   }
 
   .page-description {
-    color: #a1a1aa;
-    font-size: 1.05rem;
-    line-height: 1.6;
-    margin-bottom: 2rem;
-    max-width: 48ch;
+    color: #b4b4bb;
+    font-size: 1.02rem;
+    line-height: 1.65;
+    margin-bottom: 1.1rem;
+    max-width: 58ch;
   }
 }
 
-// ── Filter bar ───────────────────────────────────────────────────────────
+.proof-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+
+  span {
+    border-radius: 999px;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.75rem;
+    color: #d4d4d8;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+  }
+}
+
+.toolbar-stack {
+  margin-top: 1.5rem;
+  position: sticky;
+  top: 5rem;
+  z-index: 5;
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(12, 12, 14, 0.85);
+  backdrop-filter: blur(8px);
+}
+
 .filter-bar {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  width: fit-content;
   background: rgba(255, 255, 255, 0.02);
   padding: 5px;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(4px);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 
   .filter-icon {
     color: $text-muted;
@@ -78,20 +102,14 @@ $text-muted: #71717a;
     background: transparent;
     border: none;
     color: $text-muted;
-    padding: 7px 18px;
+    padding: 7px 14px;
     border-radius: 999px;
     font-weight: 700;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     cursor: pointer;
-    transition: color 0.22s ease, background 0.22s ease,
-      transform 0.15s ease;
 
     &:hover {
       color: #d4d4d8;
-    }
-
-    &:active {
-      transform: scale(0.97);
     }
 
     &.is-active {
@@ -101,56 +119,122 @@ $text-muted: #71717a;
   }
 }
 
-// ── Grid — Asymmetric masonry (taste-skill: DESIGN_VARIANCE 8) ──────────
+.toolbar-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.search-wrap,
+.sort-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: #c7c7cc;
+
+  input,
+  select {
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #f5f5f6;
+    width: 100%;
+    font-size: 0.85rem;
+  }
+
+  select option {
+    color: #111113;
+  }
+}
+
+.view-toggle {
+  display: inline-flex;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 4px;
+  width: fit-content;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.view-toggle-btn {
+  border: none;
+  background: transparent;
+  color: #a1a1aa;
+  border-radius: 999px;
+  padding: 0.42rem 0.85rem;
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+
+  &.is-active {
+    background: #27272a;
+    color: #fafafa;
+  }
+}
+
+.tech-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tech-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: #c7c7cc;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.72rem;
+  cursor: pointer;
+
+  &.is-active {
+    border-color: rgba($primary, 0.35);
+    color: $primary;
+    background: rgba($primary, 0.1);
+  }
+}
+
 .projects-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1.25rem;
+  gap: 1.15rem;
 
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
   }
 
   @media (min-width: 1024px) {
-    grid-template-columns: 1.4fr 0.6fr;
-    gap: 1.5rem;
+    grid-template-columns: 1.2fr 0.8fr;
+  }
 
-    // Alternate between wide-narrow and narrow-wide
-    .project-card:nth-child(3n + 3),
-    .project-card:nth-child(3n + 4) {
-      grid-column: auto;
+  &.is-case-study {
+    .project-card {
+      .project-bio {
+        -webkit-line-clamp: 3;
+        height: auto;
+      }
     }
   }
 }
 
-// ── Card ─────────────────────────────────────────────────────────────────
 .project-card {
   background: #0f0f11;
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  border-radius: 1.5rem;
-  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
-    border-color 0.4s ease, box-shadow 0.4s ease;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 1.2rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
   overflow: hidden;
   cursor: pointer;
-  outline: none;
 
   &:hover {
-    transform: translateY(-6px);
-    border-color: rgba($primary, 0.18);
-    box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.4),
-      inset 0 1px 0 rgba(255, 255, 255, 0.04);
-
-    .card-img {
-      transform: scale(1.04);
-    }
-
-    .card-overlay {
-      opacity: 0.7;
-    }
+    border-color: rgba($primary, 0.2);
+    box-shadow: 0 16px 36px -18px rgba(0, 0, 0, 0.55);
   }
 
   &:focus-visible {
-    border-color: rgba($primary, 0.4);
+    border-color: rgba($primary, 0.45);
     box-shadow: 0 0 0 2px rgba($primary, 0.2);
   }
 
@@ -159,54 +243,45 @@ $text-muted: #71717a;
       grid-column: span 2;
 
       .card-media {
-        height: 320px;
+        height: 280px;
       }
     }
   }
 }
 
-// ── Card media ───────────────────────────────────────────────────────────
 .card-media {
   position: relative;
-  height: 220px;
+  height: 210px;
   overflow: hidden;
 
   .card-img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+    transition: transform 0.3s ease;
   }
 
   .card-overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(
-      180deg,
-      transparent 30%,
-      rgba(0, 0, 0, 0.6) 100%
-    );
+    background: linear-gradient(180deg, transparent 32%, rgba(0, 0, 0, 0.65) 100%);
     pointer-events: none;
-    transition: opacity 0.4s ease;
   }
 }
 
-// ── Status pill ──────────────────────────────────────────────────────────
 .status-pill {
   position: absolute;
-  top: 14px;
-  right: 14px;
-  background: rgba(0, 0, 0, 0.5);
+  top: 12px;
+  right: 12px;
+  background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(16px);
-  padding: 5px 12px;
+  padding: 5px 11px;
   border-radius: 999px;
   font-size: 0.66rem;
   font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
   color: #e4e4e7;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -220,26 +295,23 @@ $text-muted: #71717a;
 
   &.active .status-dot {
     background: $primary;
-    box-shadow: 0 0 8px rgba($primary, 0.6);
   }
 
   &.building .status-dot {
     background: #facc15;
-    box-shadow: 0 0 8px rgba(250, 204, 21, 0.5);
   }
 
   &.archived .status-dot {
-    background: $text-muted;
+    background: #71717a;
   }
 }
 
-// ── Card body ────────────────────────────────────────────────────────────
 .card-body {
-  padding: 1.25rem 1.5rem 1.5rem;
+  padding: 1.15rem 1.25rem 1.3rem;
 }
 
 .project-name {
-  font-size: 1.35rem;
+  font-size: 1.22rem;
   font-weight: 800;
   color: #fafafa;
   margin-bottom: 0.4rem;
@@ -248,21 +320,35 @@ $text-muted: #71717a;
 
 .project-bio {
   color: #a1a1aa;
-  font-size: 0.88rem;
+  font-size: 0.9rem;
   line-height: 1.6;
-  height: 2.85em;
+  height: 2.8em;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
 
-// ── Tags ─────────────────────────────────────────────────────────────────
+.case-study-snippet {
+  margin-top: 0.8rem;
+
+  p {
+    margin: 0 0 0.45rem;
+    color: #bdbdc2;
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+
+  b {
+    color: #f4f4f5;
+  }
+}
+
 .tag-cloud {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin: 1rem 0 1.5rem;
+  margin: 1rem 0 1.2rem;
 
   .feature-tag {
     background: rgba(255, 255, 255, 0.03);
@@ -272,14 +358,17 @@ $text-muted: #71717a;
     font-weight: 600;
     color: $text-muted;
     border: 1px solid rgba(255, 255, 255, 0.05);
-    transition: border-color 0.2s ease, color 0.2s ease;
   }
 }
 
-// ── Actions ──────────────────────────────────────────────────────────────
 .action-row {
   display: flex;
   gap: 8px;
+
+  .btn-launch,
+  .btn-repo {
+    min-height: 42px;
+  }
 
   .btn-launch {
     flex: 1;
@@ -293,21 +382,7 @@ $text-muted: #71717a;
     border-radius: 12px;
     font-weight: 800;
     font-size: 0.82rem;
-    text-align: center;
     text-decoration: none;
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
-    box-shadow: 0 2px 10px rgba($primary, 0.15),
-      inset 0 1px 0 rgba(255, 255, 255, 0.1);
-
-    &:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 4px 16px rgba($primary, 0.22),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    }
-
-    &:active {
-      transform: scale(0.98);
-    }
   }
 
   .btn-repo {
@@ -319,93 +394,52 @@ $text-muted: #71717a;
     color: #d4d4d8;
     border-radius: 12px;
     text-decoration: none;
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(4px);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-    transition: background 0.2s ease, border-color 0.2s ease,
-      transform 0.15s ease;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: rgba(255, 255, 255, 0.1);
-    }
-
-    &:active {
-      transform: scale(0.97);
-    }
+    border: 1px solid rgba(255, 255, 255, 0.08);
   }
 }
 
-// ── Detail Modal ─────────────────────────────────────────────────────────
-.detail-overlay {
+.detail-drawer {
   position: fixed;
-  inset: 0;
-  z-index: 40;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(8px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
-}
-
-.detail-modal {
-  position: relative;
-  width: 100%;
-  max-width: 640px;
-  max-height: 90vh;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(460px, 95vw);
+  z-index: 30;
   overflow-y: auto;
   background: #111113;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 1.75rem;
-  box-shadow: 0 40px 80px -20px rgba(0, 0, 0, 0.6),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  border-left: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: -22px 0 48px -20px rgba(0, 0, 0, 0.65);
 
-  // Custom scrollbar
   &::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
+    width: 5px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 5px;
   }
 }
 
 .detail-close {
   position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 2;
-  width: 36px;
-  height: 36px;
+  top: 14px;
+  right: 14px;
+  z-index: 3;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(12px);
+  background: rgba(0, 0, 0, 0.45);
   color: #d4d4d8;
   cursor: pointer;
-  transition: background 0.2s ease, transform 0.15s ease;
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.7);
-  }
-
-  &:active {
-    transform: scale(0.95);
-  }
 }
 
 .detail-hero {
   position: relative;
-  height: 260px;
+  height: 220px;
   overflow: hidden;
 
   .detail-hero-img {
@@ -417,88 +451,67 @@ $text-muted: #71717a;
   .detail-hero-overlay {
     position: absolute;
     inset: 0;
-    background: linear-gradient(
-      180deg,
-      transparent 40%,
-      #111113 100%
-    );
-    pointer-events: none;
+    background: linear-gradient(180deg, transparent 40%, #111113 100%);
   }
 }
 
 .detail-status {
   position: absolute;
-  top: 16px;
-  left: 16px;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(16px);
-  padding: 5px 12px;
-  border-radius: 999px;
-  font-size: 0.66rem;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #e4e4e7;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-
-  .status-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #52525b;
-  }
-
-  &.active .status-dot {
-    background: $primary;
-    box-shadow: 0 0 8px rgba($primary, 0.6);
-  }
-
-  &.building .status-dot {
-    background: #facc15;
-    box-shadow: 0 0 8px rgba(250, 204, 21, 0.5);
-  }
+  top: 14px;
+  left: 14px;
 }
 
 .detail-body {
-  padding: 0 1.75rem 2rem;
+  padding: 0 1.2rem 1.5rem;
 }
 
 .detail-title {
-  font-size: 1.8rem;
+  font-size: 1.55rem;
   font-weight: 800;
   letter-spacing: -0.03em;
   color: #fafafa;
   margin-bottom: 0.75rem;
-  line-height: 1.1;
 }
 
 .detail-description {
-  font-size: 0.95rem;
-  line-height: 1.7;
+  font-size: 0.92rem;
+  line-height: 1.65;
   color: #a1a1aa;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
 .detail-section {
-  margin-bottom: 1.75rem;
+  margin-bottom: 1.2rem;
 }
 
 .detail-section-title {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: $text-muted;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.7rem;
 
   svg {
     color: $primary;
+  }
+}
+
+.detail-meta-row,
+.detail-copy {
+  font-size: 0.85rem;
+  color: #c5c5ca;
+  line-height: 1.55;
+  margin-bottom: 0.45rem;
+
+  span,
+  b {
+    color: #f5f5f6;
+    margin-right: 0.35rem;
+    font-weight: 700;
   }
 }
 
@@ -527,56 +540,31 @@ $text-muted: #71717a;
 .detail-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.45rem;
-  padding: 0.75rem 1.35rem;
-  border-radius: 14px;
+  padding: 0.72rem 1rem;
+  border-radius: 12px;
   font-weight: 700;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   text-decoration: none;
-  transition: transform 0.15s ease, box-shadow 0.15s ease,
-    opacity 0.15s ease;
-
-  &:active {
-    transform: scale(0.98);
-  }
+  flex: 1;
 
   &--primary {
-    flex: 1;
-    justify-content: center;
     background: $primary;
     color: $bg-dark;
-    box-shadow: 0 4px 16px rgba($primary, 0.2),
-      inset 0 1px 0 rgba(255, 255, 255, 0.12);
-
-    &:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 20px rgba($primary, 0.25),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12);
-    }
   }
 
   &--secondary {
-    flex: 1;
-    justify-content: center;
-    background: rgba(255, 255, 255, 0.04);
-    color: #d4d4d8;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    backdrop-filter: blur(4px);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.07);
-      border-color: rgba(255, 255, 255, 0.12);
-      color: #fafafa;
-    }
+    background: rgba(255, 255, 255, 0.05);
+    color: #e4e4e7;
+    border: 1px solid rgba(255, 255, 255, 0.1);
   }
 }
 
-// ── Skeleton cards ───────────────────────────────────────────────────────
 .skeleton-card {
   background: #0f0f11;
   border: 1px solid rgba(255, 255, 255, 0.04);
-  border-radius: 1.5rem;
+  border-radius: 1.2rem;
   overflow: hidden;
 
   &--large {
@@ -584,14 +572,14 @@ $text-muted: #71717a;
       grid-column: span 2;
 
       .skeleton-media {
-        height: 320px;
+        height: 280px;
       }
     }
   }
 }
 
 .skeleton-media {
-  height: 220px;
+  height: 210px;
   background: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0.02) 25%,
@@ -655,13 +643,12 @@ $text-muted: #71717a;
   border-radius: 12px;
 }
 
-// ── Empty state ──────────────────────────────────────────────────────────
 .projects-empty {
   text-align: center;
   padding: 4rem 1.5rem;
   border: 1px dashed rgba(255, 255, 255, 0.06);
-  border-radius: 1.5rem;
-  max-width: 480px;
+  border-radius: 1.2rem;
+  max-width: 520px;
   margin: 0 auto;
 
   .empty-title {
@@ -678,12 +665,11 @@ $text-muted: #71717a;
   }
 }
 
-// ── Error state ──────────────────────────────────────────────────────────
 .projects-error {
   text-align: center;
   padding: 2.5rem 1.5rem;
   border: 1px solid rgba(239, 68, 68, 0.12);
-  border-radius: 1.5rem;
+  border-radius: 1.2rem;
   background: rgba(239, 68, 68, 0.03);
   max-width: 480px;
   margin: 0 auto;
@@ -711,19 +697,16 @@ $text-muted: #71717a;
     font-weight: 700;
     font-size: 0.88rem;
     cursor: pointer;
-    transition: background 0.2s ease, transform 0.15s ease;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.08);
-    }
-
-    &:active {
-      transform: scale(0.98);
-    }
   }
 }
 
-// ── Large breakpoint adjustments ─────────────────────────────────────────
+@media (min-width: 768px) {
+  .toolbar-controls {
+    grid-template-columns: minmax(230px, 1fr) auto auto;
+    align-items: center;
+  }
+}
+
 @media (min-width: 1024px) {
   .projects-page {
     padding: 8rem 2rem 6rem;


### PR DESCRIPTION
### Motivation
- Reframe the Projects page to support outcome-focused case studies, faster scanning, and tooling for both business and technical audiences. 
- Provide non-blocking detail review and richer filtering so users can discover work by outcome, tech, and status. 
- Synthesize three prior conceptual directions (conversion, storytelling, data-dense) into a hybrid “Case Study + Command Center” UX. 

### Description
- Added four redesign spec files under `_redesign/` documenting Agent proposals and a synthesized plan to guide implementation. 
- Overhauled `Projects.jsx` to introduce sticky toolbar controls with status filters, search (`input[type=search]`), sort options, tech tag chips, and a view mode toggle (`Grid` / `Case Study`), plus computed `availableTags` and tag toggle behavior. 
- Replaced the blocking modal with a right-side `ProjectDrawer` (and small `DetailRow` helper), surfaced structured case-study fields (`challenge`, `approach`, `outcomes`), adjusted animations/variants, and tuned interaction accessibility attributes. 
- Updated project filtering logic to combine status, free-text search, active tech tags, and multiple sort modes (including status priority), and updated card rendering to show featured items and case-study snippets. 
- Large stylistic and layout adjustments in `projects.styles.scss` to add proof chips, toolbar styling, sticky behavior, drawer styling, condensed card treatments, reduced hover transforms, responsive tweaks, and new styles for case-study snippets and tech chips. 

### Testing
- Ran `npm run lint` locally and resolved lint errors; lint succeeded. 
- Performed a local production build via `npm run build` which completed successfully. 
- No automated unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf17dee09c83309c86c225e3b381f0)