### PR TITLE
Redesign /projects page with cleaner overview, controls, and drawer details

### DIFF
--- a/client/src/Pages/Projects/Projects.jsx
+++ b/client/src/Pages/Projects/Projects.jsx
@@ -1,698 +1,388 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
 import {
   ArrowUpRight,
-  GithubLogo,
-  X,
-  FunnelSimple,
+  FadersHorizontal,
   Globe,
-  Code,
-  Tag,
+  GithubLogo,
+  List,
   MagnifyingGlass,
-  ArrowsDownUp,
-  Sparkle,
-  ArrowRight,
+  SquaresFour,
+  X,
 } from "@phosphor-icons/react";
+import useProjects from "../../hooks/useProjects";
+import { toggleSideNav } from "../../redux/navigation/navigationSlice";
+import {
+  applyProjectFilters,
+  getCaseStudy,
+  getProjectTags,
+  SORT_OPTIONS,
+  STATUS_FILTERS,
+  VIEW_MODES,
+  normalizeStatus,
+} from "./projectUtils";
 import "./projects.styles.scss";
 
-const API_BASE = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
-const STATUS_FILTERS = ["All", "Active", "Building", "Archived"];
-const SORT_OPTIONS = ["Featured", "Name A–Z", "Name Z–A", "Status"];
-const VIEW_MODES = ["Grid", "Case Study"];
-
-const spring = { type: "spring", stiffness: 100, damping: 20 };
-
-const normalizeStatus = (s) => {
-  const v = String(s || "")
-    .trim()
-    .toLowerCase();
-
-  if (v.includes("active") || v === "live") return "active";
-  if (v.includes("build") || v.includes("progress") || v.includes("wip")) {
-    return "building";
-  }
-  if (v.includes("archiv") || v.includes("paused")) return "archived";
-  return "active";
-};
-
-const statusPriority = { active: 0, building: 1, archived: 2 };
-
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.08, delayChildren: 0.05 },
-  },
-};
-
-const cardVariants = {
-  hidden: { opacity: 0, y: 18 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: { ...spring, duration: 0.45 },
-  },
-  exit: { opacity: 0, scale: 0.98, transition: { duration: 0.2 } },
-};
-
-const drawerVariants = {
-  hidden: { x: 460, opacity: 0 },
-  visible: {
-    x: 0,
-    opacity: 1,
-    transition: { ...spring, duration: 0.45 },
-  },
-  exit: {
-    x: 420,
-    opacity: 0,
-    transition: { duration: 0.2 },
-  },
-};
-
-const overlayVariants = {
-  hidden: { opacity: 0 },
-  visible: { opacity: 1, transition: { duration: 0.2 } },
-  exit: { opacity: 0, transition: { duration: 0.18 } },
-};
-
-const SkeletonCard = ({ index }) => (
-  <div className={`skeleton-card ${index === 0 ? "skeleton-card--large" : ""}`}>
-    <div className="skeleton-media" />
-    <div className="skeleton-body">
-      <div className="skel-line skel-kicker" />
-      <div className="skel-line skel-name" />
-      <div className="skel-line skel-bio" />
-      <div className="skel-line skel-bio-short" />
-      <div className="skel-tags">
-        <div className="skel-line skel-tag" />
-        <div className="skel-line skel-tag" />
-        <div className="skel-line skel-tag" />
-      </div>
-      <div className="skel-line skel-action" />
-    </div>
-  </div>
-);
-
-const DetailRow = ({ label, value }) => {
-  if (!value) return null;
-
-  return (
-    <p className="detail-meta-row">
-      <span>{label}</span>
-      {value}
-    </p>
-  );
-};
-
 const ProjectDrawer = ({ project, onClose }) => {
-  const status = normalizeStatus(project.status);
-  const features = Array.isArray(project.features) ? project.features : [];
-  const outcome = project.outcomes || project.impact || project.result;
+  const drawerRef = useRef(null);
+  const { problem, solution, outcome } = getCaseStudy(project);
 
   useEffect(() => {
-    const handleKey = (e) => {
-      if (e.key === "Escape") onClose();
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusable = drawerRef.current?.querySelectorAll(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+      );
+
+      if (!focusable || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+
+      if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
 
     document.body.style.overflow = "hidden";
-    document.addEventListener("keydown", handleKey);
+    document.addEventListener("keydown", onKeyDown);
+
+    const initialFocus = drawerRef.current?.querySelector("button, a");
+    initialFocus?.focus();
 
     return () => {
       document.body.style.overflow = "";
-      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("keydown", onKeyDown);
     };
   }, [onClose]);
 
   return (
-    <>
-      <motion.div
-        className="drawer-backdrop"
-        variants={overlayVariants}
-        initial="hidden"
-        animate="visible"
-        exit="exit"
-        onClick={onClose}
-      />
-
-      <motion.aside
-        className="detail-drawer"
-        variants={drawerVariants}
-        initial="hidden"
-        animate="visible"
-        exit="exit"
+    <div className="projects-drawer-overlay" onClick={onClose} role="presentation">
+      <aside
+        ref={drawerRef}
+        className="projects-drawer"
         role="dialog"
         aria-modal="true"
         aria-label={`${project.name} details`}
+        onClick={(event) => event.stopPropagation()}
       >
         <button
           type="button"
-          className="detail-close"
+          className="projects-drawer-close"
           onClick={onClose}
           aria-label="Close project details"
         >
-          <X size={20} weight="bold" />
+          <X size={18} />
         </button>
 
-        <div className="detail-hero">
-          <img
-            src={project.thumbnailUrl}
-            alt={`${project.name} preview image`}
-            className="detail-hero-img"
-          />
-          <div className="detail-hero-overlay" />
-          <span className={`detail-status ${status}`}>
-            <i className="status-dot" /> {status}
-          </span>
-        </div>
-
-        <div className="detail-body">
-          <div className="detail-intro">
-            <p className="detail-eyebrow">Project overview</p>
-            <h2 className="detail-title">{project.name}</h2>
-            <p className="detail-description">{project.description}</p>
+        <header className="projects-drawer-header">
+          <img src={project.thumbnailUrl} alt={`${project.name} preview`} />
+          <div>
+            <p className={`status-chip ${normalizeStatus(project.status)}`}>{normalizeStatus(project.status)}</p>
+            <h2>{project.name}</h2>
+            <p>{project.shortDescription || project.description}</p>
           </div>
+        </header>
 
-          <div className="detail-section detail-section--meta">
-            <h3 className="detail-section-title">Overview</h3>
-            <DetailRow label="Role" value={project.role} />
-            <DetailRow label="Year" value={project.year} />
-            <DetailRow label="Status" value={status} />
-          </div>
+        {problem && (
+          <section>
+            <h3>Problem</h3>
+            <p>{problem}</p>
+          </section>
+        )}
 
-          {(project.challenge || project.approach || outcome) && (
-            <div className="detail-section">
-              <h3 className="detail-section-title">Case-study snapshot</h3>
-              {project.challenge && (
-                <p className="detail-copy">
-                  <b>Challenge:</b> {project.challenge}
-                </p>
-              )}
-              {project.approach && (
-                <p className="detail-copy">
-                  <b>Approach:</b> {project.approach}
-                </p>
-              )}
-              {outcome && (
-                <p className="detail-copy">
-                  <b>Outcome:</b> {outcome}
-                </p>
-              )}
+        {solution && (
+          <section>
+            <h3>Solution</h3>
+            <p>{solution}</p>
+          </section>
+        )}
+
+        {outcome && (
+          <section>
+            <h3>Outcome</h3>
+            <p>{outcome}</p>
+          </section>
+        )}
+
+        {Array.isArray(project.features) && project.features.length > 0 && (
+          <section>
+            <h3>Features</h3>
+            <ul>
+              {project.features.map((feature) => (
+                <li key={feature}>{feature}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {Array.isArray(project.technologies) && project.technologies.length > 0 && (
+          <section>
+            <h3>Tech stack</h3>
+            <div className="drawer-tags">
+              {project.technologies.map((tech) => (
+                <span key={tech}>{tech}</span>
+              ))}
             </div>
+          </section>
+        )}
+
+        <footer className="drawer-actions">
+          {project.demoUrl && (
+            <a href={project.demoUrl} target="_blank" rel="noreferrer">
+              <Globe size={16} /> Live
+            </a>
           )}
-
-          {features.length > 0 && (
-            <div className="detail-section">
-              <h3 className="detail-section-title">
-                <Tag size={16} weight="duotone" />
-                Tech stack
-              </h3>
-              <div className="detail-tags">
-                {features.map((tag) => (
-                  <span key={tag} className="detail-tag">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </div>
+          {project.repoUrl && (
+            <a href={project.repoUrl} target="_blank" rel="noreferrer">
+              <GithubLogo size={16} /> Repo
+            </a>
           )}
-
-          <div className="detail-actions">
-            {project.demoUrl && (
-              <a
-                href={project.demoUrl}
-                className="detail-btn detail-btn--primary"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Globe size={18} weight="duotone" />
-                Visit live site
-                <ArrowUpRight size={16} weight="bold" />
-              </a>
-            )}
-
-            {project.repoUrl && (
-              <a
-                href={project.repoUrl}
-                className="detail-btn detail-btn--secondary"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <Code size={18} weight="duotone" />
-                View source
-                <ArrowUpRight size={16} weight="bold" />
-              </a>
-            )}
-          </div>
-        </div>
-      </motion.aside>
-    </>
+        </footer>
+      </aside>
+    </div>
   );
 };
 
 const Projects = () => {
-  const [projects, setProjects] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [statusFilter, setStatusFilter] = useState("All");
+  const dispatch = useDispatch();
   const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("All");
   const [sortBy, setSortBy] = useState("Featured");
   const [viewMode, setViewMode] = useState("Grid");
   const [activeTags, setActiveTags] = useState([]);
-  const [selected, setSelected] = useState(null);
+  const [selectedProject, setSelectedProject] = useState(null);
+  const [showFilters, setShowFilters] = useState(false);
 
-  useEffect(() => {
-    const fetchProjects = async () => {
-      try {
-        const res = await fetch(`${API_BASE}/api/projects`);
+  const { data, isLoading, isError, error } = useProjects();
+  const projects = useMemo(() => (Array.isArray(data) ? data : data?.data || []), [data]);
 
-        if (!res.ok) {
-          throw new Error(`Request failed with status ${res.status}`);
-        }
+  const tags = useMemo(() => getProjectTags(projects), [projects]);
 
-        const json = await res.json();
-        setProjects(Array.isArray(json) ? json : json.data || []);
-      } catch (e) {
-        console.error("Fetch error:", e);
-        setError(
-          "Failed to load projects. Check your connection and try again.",
-        );
-      } finally {
-        setLoading(false);
-      }
-    };
+  const filteredProjects = useMemo(
+    () =>
+      applyProjectFilters({
+        projects,
+        statusFilter,
+        search,
+        activeTags,
+        sortBy,
+      }),
+    [projects, statusFilter, search, activeTags, sortBy],
+  );
 
-    fetchProjects();
-  }, []);
+  const featuredProject = useMemo(
+    () => filteredProjects.find((project) => project.featured) || filteredProjects[0] || null,
+    [filteredProjects],
+  );
 
-  const availableTags = useMemo(() => {
-    const tags = projects.flatMap((p) =>
-      Array.isArray(p.features) ? p.features : [],
-    );
+  const hasActiveFilters =
+    statusFilter !== "All" || search.trim() || sortBy !== "Featured" || activeTags.length > 0;
 
-    return [...new Set(tags)]
-      .filter(Boolean)
-      .sort((a, b) => a.localeCompare(b))
-      .slice(0, 12);
-  }, [projects]);
-
-  const filtered = useMemo(() => {
-    let list = [...projects];
-
-    if (statusFilter !== "All") {
-      list = list.filter(
-        (p) => normalizeStatus(p.status) === statusFilter.toLowerCase(),
-      );
-    }
-
-    if (search.trim()) {
-      const query = search.trim().toLowerCase();
-
-      list = list.filter((p) => {
-        const haystack = [p.name, p.description, ...(p.features || [])]
-          .join(" ")
-          .toLowerCase();
-
-        return haystack.includes(query);
-      });
-    }
-
-    if (activeTags.length > 0) {
-      list = list.filter((p) => {
-        const tags = Array.isArray(p.features) ? p.features : [];
-        return activeTags.every((tag) => tags.includes(tag));
-      });
-    }
-
-    if (sortBy === "Name A–Z") {
-      list.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
-    } else if (sortBy === "Name Z–A") {
-      list.sort((a, b) => (b.name || "").localeCompare(a.name || ""));
-    } else if (sortBy === "Status") {
-      list.sort(
-        (a, b) =>
-          statusPriority[normalizeStatus(a.status)] -
-          statusPriority[normalizeStatus(b.status)],
-      );
-    }
-
-    return list;
-  }, [projects, statusFilter, search, activeTags, sortBy]);
-
-  const featuredProject = filtered[0] || null;
-  const projectCountLabel = filtered.length === 1 ? "project" : "projects";
-
-  const handleClose = useCallback(() => setSelected(null), []);
-
-  const toggleTag = (tag) => {
-    setActiveTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
-    );
-  };
-
-  const clearFilters = () => {
-    setStatusFilter("All");
+  const resetFilters = () => {
     setSearch("");
+    setStatusFilter("All");
     setSortBy("Featured");
-    setViewMode("Grid");
     setActiveTags([]);
   };
 
   return (
     <main className="projects-page">
-      <section className="projects-hero">
-        <div className="projects-hero__bg" />
+      <div className="projects-shell">
+        <button type="button" className="projects-nav-trigger" onClick={() => dispatch(toggleSideNav())}>
+          <List size={16} /> Menu
+        </button>
 
-        <header className="projects-header">
-          <motion.div
-            className="hero-copy"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ ...spring, duration: 0.6 }}
-          >
-            <span className="projects-eyebrow">Selected work</span>
-            <h1 className="page-title">
-              Design, engineering, and shipped outcomes
-            </h1>
-            <p className="page-description">
-              A cleaner portfolio experience built around product thinking,
-              implementation depth, and launch-ready execution.
-            </p>
+        <section className="projects-intro">
+          <h1>Projects</h1>
+          <p>Shipped builds across product, AI, and systems.</p>
+        </section>
 
-            <div className="proof-chips" aria-label="Portfolio highlights">
-              <span>{projects.length} Projects</span>
-              <span>{availableTags.length} Core technologies</span>
-              <span>Outcome-driven builds</span>
-            </div>
-          </motion.div>
-
-          <motion.div
-            className="hero-spotlight"
-            initial={{ opacity: 0, x: 16 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ ...spring, duration: 0.6, delay: 0.12 }}
-          >
-            <div className="spotlight-card">
-              <div className="spotlight-top">
-                <span className="spotlight-badge">
-                  <Sparkle size={14} weight="fill" />
-                  Featured
-                </span>
-                <span className="spotlight-count">
-                  {filtered.length} {projectCountLabel}
-                </span>
-              </div>
-
-              <div className="spotlight-body">
-                <h2>{featuredProject?.name || "Portfolio system"}</h2>
-                <p>
-                  {featuredProject?.description ||
-                    "Refined interface for case studies, filters, and deeper project storytelling."}
-                </p>
-              </div>
-
-              <button
-                type="button"
-                className="spotlight-action"
-                onClick={() => {
-                  if (featuredProject) setSelected(featuredProject);
-                }}
-                disabled={!featuredProject}
-              >
-                Open featured project
-                <ArrowRight size={16} weight="bold" />
-              </button>
-            </div>
-          </motion.div>
-        </header>
-      </section>
-
-      <motion.section
-        className="projects-toolbar-shell"
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ ...spring, duration: 0.5, delay: 0.15 }}
-      >
-        <div className="toolbar-stack">
-          <div className="toolbar-top">
-            <nav className="filter-bar" aria-label="Filter projects by status">
-              <FunnelSimple
-                size={14}
-                weight="bold"
-                className="filter-icon"
-                aria-hidden="true"
-              />
-
-              {STATUS_FILTERS.map((f) => (
-                <button
-                  key={f}
-                  type="button"
-                  onClick={() => setStatusFilter(f)}
-                  className={`filter-btn ${statusFilter === f ? "is-active" : ""}`}
-                >
-                  {f}
+        {featuredProject && (
+          <section className="featured-project">
+            <div>
+              <p className="featured-label">Featured build</p>
+              <h2>{featuredProject.name}</h2>
+              <p>{featuredProject.shortDescription || featuredProject.description}</p>
+              <ul>
+                {(featuredProject.features || []).slice(0, 3).map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+              <div className="featured-actions">
+                <button type="button" onClick={() => setSelectedProject(featuredProject)}>
+                  View Case Study
                 </button>
-              ))}
-            </nav>
+                {featuredProject.demoUrl && (
+                  <a href={featuredProject.demoUrl} target="_blank" rel="noreferrer">
+                    Live Site <ArrowUpRight size={14} />
+                  </a>
+                )}
+              </div>
+            </div>
+            <img src={featuredProject.thumbnailUrl} alt={`${featuredProject.name} preview`} />
+          </section>
+        )}
 
-            <button type="button" className="clear-btn" onClick={clearFilters}>
+        <section className="projects-toolbar">
+          <label className="search-control" htmlFor="project-search">
+            <MagnifyingGlass size={15} />
+            <input
+              id="project-search"
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search projects"
+            />
+          </label>
+
+          <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+            {STATUS_FILTERS.map((option) => (
+              <option key={option}>{option}</option>
+            ))}
+          </select>
+
+          <select value={sortBy} onChange={(event) => setSortBy(event.target.value)}>
+            {SORT_OPTIONS.map((option) => (
+              <option key={option}>{option}</option>
+            ))}
+          </select>
+
+          <div className="view-toggle" role="tablist" aria-label="Project view mode">
+            {VIEW_MODES.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className={viewMode === mode ? "active" : ""}
+                onClick={() => setViewMode(mode)}
+              >
+                {mode === "Grid" ? <SquaresFour size={14} /> : <List size={14} />} {mode}
+              </button>
+            ))}
+          </div>
+
+          <button type="button" className="filter-toggle" onClick={() => setShowFilters((open) => !open)}>
+            <FadersHorizontal size={15} /> Filters
+          </button>
+
+          {hasActiveFilters && (
+            <button type="button" className="reset-control" onClick={resetFilters}>
               Reset
             </button>
-          </div>
-
-          <div className="toolbar-controls">
-            <label className="search-wrap" htmlFor="projects-search">
-              <MagnifyingGlass size={16} weight="bold" aria-hidden="true" />
-              <input
-                id="projects-search"
-                type="search"
-                placeholder="Search by name, description, or tech"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-              />
-            </label>
-
-            <label className="sort-wrap" htmlFor="projects-sort">
-              <ArrowsDownUp size={14} weight="bold" aria-hidden="true" />
-              <select
-                id="projects-sort"
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value)}
-              >
-                {SORT_OPTIONS.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <div
-              className="view-toggle"
-              role="tablist"
-              aria-label="Select view mode"
-            >
-              {VIEW_MODES.map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  role="tab"
-                  aria-selected={viewMode === mode}
-                  className={`view-toggle-btn ${viewMode === mode ? "is-active" : ""}`}
-                  onClick={() => setViewMode(mode)}
-                >
-                  {mode}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {availableTags.length > 0 && (
-            <div className="tech-filter" aria-label="Filter by technology">
-              {availableTags.map((tag) => (
-                <button
-                  key={tag}
-                  type="button"
-                  onClick={() => toggleTag(tag)}
-                  className={`tech-chip ${activeTags.includes(tag) ? "is-active" : ""}`}
-                >
-                  {tag}
-                </button>
-              ))}
-            </div>
           )}
-        </div>
-      </motion.section>
+        </section>
 
-      {loading && (
-        <div className="projects-grid">
-          {[0, 1, 2, 3].map((i) => (
-            <SkeletonCard key={i} index={i} />
-          ))}
-        </div>
-      )}
+        {showFilters && tags.length > 0 && (
+          <section className="filters-drawer">
+            {tags.map((tag) => (
+              <button
+                type="button"
+                key={tag}
+                className={activeTags.includes(tag) ? "active" : ""}
+                onClick={() =>
+                  setActiveTags((previous) =>
+                    previous.includes(tag)
+                      ? previous.filter((item) => item !== tag)
+                      : [...previous, tag],
+                  )
+                }
+              >
+                {tag}
+              </button>
+            ))}
+          </section>
+        )}
 
-      {!loading && error && (
-        <div className="projects-error">
-          <p className="error-title">Something went wrong</p>
-          <p className="error-text">{error}</p>
-          <button
-            type="button"
-            className="retry-btn"
-            onClick={() => window.location.reload()}
-          >
-            Retry
-          </button>
-        </div>
-      )}
-
-      {!loading && !error && filtered.length === 0 && (
-        <motion.div
-          className="projects-empty"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.4 }}
-        >
-          <p className="empty-title">No projects found</p>
-          <p className="empty-text">
-            Try adjusting search text, tags, or status filters.
+        {hasActiveFilters && (
+          <p className="active-summary">
+            {filteredProjects.length} result(s) • status: {statusFilter} • sort: {sortBy}
+            {activeTags.length > 0 ? ` • tags: ${activeTags.join(", ")}` : ""}
           </p>
-        </motion.div>
-      )}
+        )}
 
-      {!loading && !error && filtered.length > 0 && (
-        <motion.section
-          className={`projects-grid ${viewMode === "Case Study" ? "is-case-study" : ""}`}
-          variants={containerVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          <AnimatePresence mode="popLayout">
-            {filtered.map((p, index) => {
-              const status = normalizeStatus(p.status);
-              const key = p._id || p.id || p.name;
-              const outcome = p.outcomes || p.impact || p.result;
+        {isLoading && <p className="projects-state">Loading projects…</p>}
+        {isError && <p className="projects-state">{error?.message || "Failed to load projects."}</p>}
 
+        {!isLoading && !isError && filteredProjects.length === 0 && (
+          <p className="projects-state">No projects found. Try a different search or filter.</p>
+        )}
+
+        {!isLoading && !isError && filteredProjects.length > 0 && viewMode === "Grid" && (
+          <section className="projects-grid">
+            {filteredProjects.map((project) => (
+              <article key={project._id || project.id || project.slug || project.name} className="project-card">
+                <img src={project.thumbnailUrl} alt={`${project.name} cover`} />
+                <p className={`status-chip ${normalizeStatus(project.status)}`}>{normalizeStatus(project.status)}</p>
+                <h3>{project.name}</h3>
+                <p>{project.shortDescription || project.description}</p>
+                <div className="card-tags">
+                  {(project.features || []).slice(0, 3).map((tag) => (
+                    <span key={tag}>{tag}</span>
+                  ))}
+                </div>
+                <div className="card-actions">
+                  <button type="button" onClick={() => setSelectedProject(project)}>
+                    View
+                  </button>
+                  {project.demoUrl && (
+                    <a href={project.demoUrl} target="_blank" rel="noreferrer">
+                      Live
+                    </a>
+                  )}
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
+
+        {!isLoading && !isError && filteredProjects.length > 0 && viewMode === "Case Study" && (
+          <section className="case-study-list">
+            {filteredProjects.map((project) => {
+              const { problem, solution, outcome } = getCaseStudy(project);
               return (
-                <motion.article
-                  className={`project-card ${index < 2 ? "project-card--featured" : ""}`}
-                  key={key}
-                  variants={cardVariants}
-                  layout
-                  exit="exit"
-                  onClick={() => setSelected(p)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      setSelected(p);
-                    }
-                  }}
-                >
-                  <div className="card-media">
-                    <img
-                      src={p.thumbnailUrl}
-                      alt={`${p.name} project cover`}
-                      className="card-img"
-                      loading="lazy"
-                    />
-                    <div className="card-overlay" />
-                    <span className={`status-pill ${status}`}>
-                      <i className="status-dot" /> {status}
-                    </span>
-                  </div>
-
-                  <div className="card-body">
-                    <div className="card-head">
-                      <span className="card-kicker">
-                        {p.role || "Product build"}
-                      </span>
-                      {p.year ? (
-                        <span className="card-year">{p.year}</span>
-                      ) : null}
+                <article key={project._id || project.id || project.slug || project.name} className="case-study-card">
+                  <h3>{project.name}</h3>
+                  {problem && (
+                    <div>
+                      <h4>Problem</h4>
+                      <p>{problem}</p>
                     </div>
-
-                    <h2 className="project-name">{p.name}</h2>
-                    <p className="project-bio">{p.description}</p>
-
-                    {viewMode === "Case Study" && (
-                      <div className="case-study-snippet">
-                        <p>
-                          <b>Challenge:</b>{" "}
-                          {p.challenge ||
-                            "Scaling product quality while keeping delivery speed high."}
-                        </p>
-                        <p>
-                          <b>Approach:</b>{" "}
-                          {p.approach ||
-                            "Iterative product delivery with focused engineering tradeoffs."}
-                        </p>
-                        <p>
-                          <b>Outcome:</b>{" "}
-                          {outcome ||
-                            "Improved launch readiness, stability, and user-facing polish."}
-                        </p>
-                      </div>
-                    )}
-
-                    <div className="tag-cloud">
-                      {(p.features || []).slice(0, 4).map((tag) => (
-                        <span key={tag} className="feature-tag">
-                          {tag}
-                        </span>
-                      ))}
+                  )}
+                  {solution && (
+                    <div>
+                      <h4>Solution</h4>
+                      <p>{solution}</p>
                     </div>
-
-                    <div className="action-row">
-                      <button
-                        type="button"
-                        className="card-open-btn"
-                        onClick={() => setSelected(p)}
-                      >
-                        View details
-                        <ArrowRight size={14} weight="bold" />
-                      </button>
-
-                      <div className="action-links">
-                        {p.demoUrl && (
-                          <a
-                            href={p.demoUrl}
-                            className="btn-launch"
-                            target="_blank"
-                            rel="noreferrer"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Globe size={16} weight="duotone" />
-                            Launch site
-                            <ArrowUpRight size={14} weight="bold" />
-                          </a>
-                        )}
-
-                        {p.repoUrl && (
-                          <a
-                            href={p.repoUrl}
-                            className="btn-repo"
-                            target="_blank"
-                            rel="noreferrer"
-                            onClick={(e) => e.stopPropagation()}
-                            aria-label={`View ${p.name} source on GitHub`}
-                          >
-                            <GithubLogo size={20} weight="fill" />
-                          </a>
-                        )}
-                      </div>
+                  )}
+                  {outcome && (
+                    <div>
+                      <h4>Outcome</h4>
+                      <p>{outcome}</p>
                     </div>
-                  </div>
-                </motion.article>
+                  )}
+                  <button type="button" onClick={() => setSelectedProject(project)}>
+                    Open Project
+                  </button>
+                </article>
               );
             })}
-          </AnimatePresence>
-        </motion.section>
-      )}
+          </section>
+        )}
+      </div>
 
-      <AnimatePresence>
-        {selected && <ProjectDrawer project={selected} onClose={handleClose} />}
-      </AnimatePresence>
+      {selectedProject && <ProjectDrawer project={selectedProject} onClose={() => setSelectedProject(null)} />}
     </main>
   );
 };

--- a/client/src/Pages/Projects/projectUtils.js
+++ b/client/src/Pages/Projects/projectUtils.js
@@ -1,0 +1,86 @@
+export const STATUS_FILTERS = ["All", "Active", "Building", "Archived"];
+export const SORT_OPTIONS = ["Featured", "Name A–Z", "Name Z–A", "Status"];
+export const VIEW_MODES = ["Grid", "Case Study"];
+
+export const normalizeStatus = (status) => {
+  const value = String(status || "")
+    .trim()
+    .toLowerCase();
+
+  if (value.includes("active") || value === "live") return "active";
+  if (value.includes("build") || value.includes("progress") || value.includes("wip")) {
+    return "building";
+  }
+  if (value.includes("archiv") || value.includes("paused")) return "archived";
+
+  return "active";
+};
+
+const statusPriority = { active: 0, building: 1, archived: 2 };
+
+export const getProjectTags = (projects = []) => {
+  return [...new Set(projects.flatMap((project) => project?.features || []))]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b))
+    .slice(0, 12);
+};
+
+export const applyProjectFilters = ({
+  projects = [],
+  statusFilter = "All",
+  search = "",
+  activeTags = [],
+  sortBy = "Featured",
+}) => {
+  let filtered = [...projects];
+
+  if (statusFilter !== "All") {
+    filtered = filtered.filter(
+      (project) => normalizeStatus(project.status) === statusFilter.toLowerCase(),
+    );
+  }
+
+  if (search.trim()) {
+    const query = search.trim().toLowerCase();
+    filtered = filtered.filter((project) => {
+      const haystack = [project.name, project.shortDescription, project.description, ...(project.features || [])]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }
+
+  if (activeTags.length > 0) {
+    filtered = filtered.filter((project) => {
+      const tags = Array.isArray(project.features) ? project.features : [];
+      return activeTags.every((tag) => tags.includes(tag));
+    });
+  }
+
+  if (sortBy === "Name A–Z") {
+    filtered.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+  } else if (sortBy === "Name Z–A") {
+    filtered.sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+  } else if (sortBy === "Status") {
+    filtered.sort(
+      (a, b) =>
+        statusPriority[normalizeStatus(a.status)] - statusPriority[normalizeStatus(b.status)],
+    );
+  } else {
+    filtered.sort((a, b) => {
+      if (a.featured && !b.featured) return -1;
+      if (!a.featured && b.featured) return 1;
+      return 0;
+    });
+  }
+
+  return filtered;
+};
+
+export const getCaseStudy = (project) => {
+  return {
+    problem: project.challenge || project.problem,
+    solution: project.approach || project.solution,
+    outcome: project.outcome || project.outcomes || project.impact || project.result,
+  };
+};

--- a/client/src/Pages/Projects/projects.styles.scss
+++ b/client/src/Pages/Projects/projects.styles.scss
@@ -1,975 +1,359 @@
-:root {
-  --projects-bg: #07111f;
-  --projects-surface: rgba(11, 20, 35, 0.78);
-  --projects-surface-strong: rgba(13, 24, 42, 0.96);
-  --projects-border: rgba(255, 255, 255, 0.08);
-  --projects-border-strong: rgba(255, 255, 255, 0.14);
-  --projects-text: #f5f7fb;
-  --projects-text-soft: rgba(245, 247, 251, 0.74);
-  --projects-text-muted: rgba(245, 247, 251, 0.52);
-  --projects-accent: #7c9cff;
-  --projects-accent-2: #8ef2d0;
-  --projects-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
-  --projects-radius-xl: 28px;
-  --projects-radius-lg: 22px;
-  --projects-radius-md: 16px;
-  --projects-radius-sm: 12px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 .projects-page {
   min-height: 100vh;
-  padding: 24px;
-  color: var(--projects-text);
-  background:
-    radial-gradient(
-      circle at top left,
-      rgba(124, 156, 255, 0.16),
-      transparent 28%
-    ),
-    radial-gradient(
-      circle at top right,
-      rgba(142, 242, 208, 0.1),
-      transparent 22%
-    ),
-    linear-gradient(180deg, #050c16 0%, #091220 48%, #08101c 100%);
+  background: #f6f8fb;
+  color: #0f172a;
+  padding: 20px;
 }
 
-.projects-hero {
-  position: relative;
-  margin: 0 auto 24px;
-  max-width: 1440px;
-  overflow: hidden;
-  border: 1px solid var(--projects-border);
-  border-radius: 32px;
-  background:
-    linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0.04),
-      rgba(255, 255, 255, 0.015)
-    ),
-    rgba(7, 15, 27, 0.88);
-  box-shadow: var(--projects-shadow);
-}
-
-.projects-hero__bg {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(
-      circle at 18% 18%,
-      rgba(124, 156, 255, 0.2),
-      transparent 24%
-    ),
-    radial-gradient(
-      circle at 84% 22%,
-      rgba(142, 242, 208, 0.14),
-      transparent 18%
-    ),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 100%);
-}
-
-.projects-header {
-  position: relative;
-  z-index: 1;
+.projects-shell {
+  max-width: 1280px;
+  margin: 0 auto;
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(320px, 420px);
   gap: 24px;
-  align-items: stretch;
-  padding: 34px;
 }
 
-.hero-copy {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.projects-eyebrow,
-.detail-eyebrow {
-  display: inline-flex;
-  align-items: center;
+.projects-nav-trigger {
   width: fit-content;
-  padding: 8px 12px;
-  border: 1px solid rgba(124, 156, 255, 0.18);
-  border-radius: 999px;
-  background: rgba(124, 156, 255, 0.08);
-  color: #dbe5ff;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.page-title {
-  margin: 18px 0 12px;
-  max-width: 12ch;
-  font-size: clamp(2.5rem, 5vw, 4.75rem);
-  line-height: 0.95;
-  letter-spacing: -0.04em;
-}
-
-.page-description {
-  margin: 0;
-  max-width: 60ch;
-  color: var(--projects-text-soft);
-  font-size: 1rem;
-  line-height: 1.7;
-}
-
-.proof-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 24px;
-
-  span {
-    padding: 10px 14px;
-    border: 1px solid var(--projects-border);
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.04);
-    color: var(--projects-text-soft);
-    font-size: 0.88rem;
-    font-weight: 600;
-  }
-}
-
-.hero-spotlight {
-  display: flex;
-}
-
-.spotlight-card {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 22px;
-  padding: 24px;
-  border: 1px solid var(--projects-border);
-  border-radius: 26px;
-  background:
-    linear-gradient(
-      180deg,
-      rgba(124, 156, 255, 0.12),
-      rgba(255, 255, 255, 0.02)
-    ),
-    rgba(10, 18, 31, 0.9);
-  backdrop-filter: blur(16px);
-}
-
-.spotlight-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.spotlight-badge {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 9px 12px;
-  border-radius: 999px;
-  background: rgba(142, 242, 208, 0.12);
-  color: #d5fff4;
-  font-size: 0.85rem;
-  font-weight: 700;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 10px;
+  padding: 8px 12px;
 }
 
-.spotlight-count {
-  color: var(--projects-text-muted);
-  font-size: 0.88rem;
-  font-weight: 600;
+.projects-intro h1 {
+  margin: 0;
+  font-size: 2rem;
 }
 
-.spotlight-body {
-  h2 {
-    margin: 0 0 10px;
-    font-size: 1.55rem;
-    letter-spacing: -0.03em;
-  }
-
-  p {
-    margin: 0;
-    color: var(--projects-text-soft);
-    line-height: 1.7;
-  }
+.projects-intro p {
+  margin: 8px 0 0;
+  color: #475569;
 }
 
-.spotlight-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.featured-project {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 20px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px;
+}
+
+.featured-project img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 12px;
+}
+
+.featured-label {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.featured-project h2 {
+  margin: 10px 0 8px;
+}
+
+.featured-project p {
+  margin: 0;
+  color: #334155;
+}
+
+.featured-project ul {
+  margin: 14px 0;
+  padding-left: 18px;
+  color: #475569;
+}
+
+.featured-actions {
+  display: flex;
   gap: 10px;
-  min-height: 52px;
-  padding: 0 16px;
+}
+
+.featured-actions button,
+.featured-actions a,
+.card-actions button,
+.card-actions a,
+.case-study-card button,
+.drawer-actions a,
+.projects-drawer-close,
+.projects-toolbar button,
+.filters-drawer button {
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  border-radius: 10px;
+  padding: 8px 12px;
+  text-decoration: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.featured-actions button,
+.card-actions button,
+.case-study-card button,
+.drawer-actions a:first-child {
+  background: #0f172a;
+  color: #fff;
+  border-color: #0f172a;
+}
+
+.projects-toolbar {
+  display: grid;
+  grid-template-columns: 1.5fr repeat(2, minmax(120px, 180px)) auto auto auto;
+  gap: 10px;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.search-control {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0 10px;
+  background: #fff;
+}
+
+.search-control input,
+.projects-toolbar select {
   border: 0;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #f5f7fb 0%, #dce5ff 100%);
-  color: #08111f;
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    opacity 0.2s ease;
-
-  &:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 20px 50px rgba(124, 156, 255, 0.16);
-  }
-
-  &:disabled {
-    opacity: 0.55;
-    cursor: not-allowed;
-  }
-}
-
-.projects-toolbar-shell {
-  position: sticky;
-  top: 18px;
-  z-index: 20;
-  margin: 0 auto 28px;
-  max-width: 1440px;
-}
-
-.toolbar-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 18px;
-  border: 1px solid var(--projects-border);
-  border-radius: 24px;
-  background: rgba(7, 14, 25, 0.72);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.18);
-}
-
-.toolbar-top,
-.toolbar-controls,
-.filter-bar,
-.tech-filter,
-.view-toggle,
-.action-links,
-.action-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.toolbar-top {
-  justify-content: space-between;
-}
-
-.filter-bar {
-  flex-wrap: wrap;
-}
-
-.filter-icon {
-  color: var(--projects-text-muted);
-}
-
-.filter-btn,
-.view-toggle-btn,
-.tech-chip,
-.clear-btn {
-  min-height: 42px;
-  padding: 0 14px;
-  border: 1px solid var(--projects-border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--projects-text-soft);
-  font-size: 0.92rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    border-color 0.2s ease,
-    background 0.2s ease,
-    color 0.2s ease;
-
-  &:hover {
-    transform: translateY(-1px);
-    border-color: var(--projects-border-strong);
-    color: var(--projects-text);
-  }
-
-  &.is-active {
-    border-color: rgba(124, 156, 255, 0.3);
-    background: rgba(124, 156, 255, 0.14);
-    color: #eff3ff;
-  }
-}
-
-.clear-btn {
+  outline: none;
+  min-height: 36px;
   background: transparent;
+  width: 100%;
 }
 
-.toolbar-controls {
-  flex-wrap: wrap;
-}
-
-.search-wrap,
-.sort-wrap {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-height: 52px;
-  padding: 0 16px;
-  border: 1px solid var(--projects-border);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.035);
-  color: var(--projects-text-muted);
-
-  input,
-  select {
-    min-width: 0;
-    border: 0;
-    outline: 0;
-    background: transparent;
-    color: var(--projects-text);
-    font: inherit;
-  }
-
-  input {
-    width: 320px;
-
-    &::placeholder {
-      color: var(--projects-text-muted);
-    }
-
-    &::-webkit-search-cancel-button {
-      appearance: none;
-    }
-  }
-
-  select {
-    cursor: pointer;
-  }
-}
-
-.search-wrap {
-  flex: 1 1 320px;
-}
-
-.sort-wrap {
-  flex: 0 0 auto;
+.projects-toolbar select {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0 10px;
 }
 
 .view-toggle {
-  padding: 4px;
-  border: 1px solid var(--projects-border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  gap: 6px;
 }
 
-.view-toggle-btn {
-  min-height: 40px;
-  border-color: transparent;
-  background: transparent;
-
-  &.is-active {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: transparent;
-  }
+.view-toggle button.active,
+.filters-drawer button.active {
+  background: #0f172a;
+  color: #fff;
+  border-color: #0f172a;
 }
 
-.tech-filter {
+.filters-drawer {
+  display: flex;
   flex-wrap: wrap;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  background: #fff;
 }
 
-.tech-chip {
-  min-height: 38px;
-  padding: 0 12px;
-  border-radius: 12px;
-  font-size: 0.84rem;
+.active-summary,
+.projects-state {
+  margin: 0;
+  color: #475569;
 }
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 20px;
-  max-width: 1440px;
-  margin: 0 auto;
-}
-
-.project-card,
-.skeleton-card {
-  grid-column: span 4;
-  overflow: hidden;
-  border: 1px solid var(--projects-border);
-  border-radius: var(--projects-radius-xl);
-  background:
-    linear-gradient(
-      180deg,
-      rgba(255, 255, 255, 0.035),
-      rgba(255, 255, 255, 0.02)
-    ),
-    rgba(9, 17, 29, 0.92);
-  box-shadow: var(--projects-shadow);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
 }
 
 .project-card {
-  display: flex;
-  flex-direction: column;
-  cursor: pointer;
-  transition:
-    transform 0.24s ease,
-    border-color 0.24s ease,
-    box-shadow 0.24s ease;
-
-  &:hover {
-    transform: translateY(-6px);
-    border-color: rgba(124, 156, 255, 0.22);
-    box-shadow: 0 26px 60px rgba(0, 0, 0, 0.3);
-  }
-
-  &:focus-visible {
-    outline: 2px solid rgba(124, 156, 255, 0.55);
-    outline-offset: 4px;
-  }
-
-  &--featured {
-    grid-column: span 6;
-  }
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 12px;
+  background: #fff;
+  display: grid;
+  gap: 10px;
 }
 
-.projects-grid.is-case-study {
-  .project-card {
-    grid-column: span 6;
-  }
-}
-
-.card-media,
-.detail-hero,
-.skeleton-media {
-  position: relative;
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.card-media {
-  aspect-ratio: 16 / 10;
-}
-
-.detail-hero {
-  aspect-ratio: 16 / 9;
-  border-bottom: 1px solid var(--projects-border);
-}
-
-.card-img,
-.detail-hero-img {
+.project-card img {
   width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.status-chip {
+  width: fit-content;
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: capitalize;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 4px 8px;
+}
+
+.status-chip.active {
+  color: #166534;
+  border-color: #86efac;
+}
+
+.status-chip.building {
+  color: #92400e;
+  border-color: #fcd34d;
+}
+
+.status-chip.archived {
+  color: #334155;
+  border-color: #cbd5e1;
+}
+
+.project-card h3,
+.project-card p {
+  margin: 0;
+}
+
+.project-card p {
+  color: #475569;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.card-tags span,
+.drawer-tags span {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  color: #334155;
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.case-study-list {
+  display: grid;
+  gap: 14px;
+}
+
+.case-study-card {
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.case-study-card h3,
+.case-study-card h4,
+.case-study-card p {
+  margin: 0;
+}
+
+.case-study-card p {
+  color: #475569;
+}
+
+.projects-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 200;
+}
+
+.projects-drawer {
+  width: min(680px, 100%);
+  background: #fff;
   height: 100%;
-  display: block;
+  padding: 18px;
+  overflow: auto;
+  display: grid;
+  gap: 14px;
+}
+
+.projects-drawer-close {
+  justify-self: end;
+}
+
+.projects-drawer-header {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 14px;
+}
+
+.projects-drawer-header img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: 10px;
   object-fit: cover;
 }
 
-.card-overlay,
-.detail-hero-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    180deg,
-    transparent 26%,
-    rgba(2, 8, 16, 0.84) 100%
-  );
-}
-
-.status-pill,
-.detail-status {
-  position: absolute;
-  left: 16px;
-  top: 16px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 34px;
-  padding: 0 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(5, 11, 20, 0.72);
-  backdrop-filter: blur(10px);
-  color: #f7f9ff;
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-transform: capitalize;
-
-  &.active {
-    color: #c8ffeb;
-  }
-
-  &.building {
-    color: #fff2bf;
-  }
-
-  &.archived {
-    color: #d6deef;
-  }
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: currentColor;
-}
-
-.card-body,
-.skeleton-body {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 22px;
-}
-
-.card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.card-kicker,
-.card-year {
-  color: var(--projects-text-muted);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.project-name {
+.projects-drawer h2,
+.projects-drawer h3,
+.projects-drawer p {
   margin: 0;
-  font-size: 1.42rem;
-  line-height: 1.1;
-  letter-spacing: -0.03em;
 }
 
-.project-bio,
-.detail-description,
-.detail-copy,
-.empty-text,
-.error-text {
-  margin: 0;
-  color: var(--projects-text-soft);
-  line-height: 1.7;
+.projects-drawer p,
+.projects-drawer li {
+  color: #475569;
 }
 
-.case-study-snippet {
-  display: grid;
-  gap: 10px;
-  padding: 16px;
-  border: 1px solid var(--projects-border);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.03);
-
-  p {
-    margin: 0;
-    color: var(--projects-text-soft);
-    line-height: 1.65;
-  }
-
-  b {
-    color: var(--projects-text);
-  }
-}
-
-.tag-cloud,
-.detail-tags,
-.skel-tags {
+.drawer-actions {
   display: flex;
-  flex-wrap: wrap;
   gap: 10px;
 }
 
-.feature-tag,
-.detail-tag {
-  display: inline-flex;
-  align-items: center;
-  min-height: 34px;
-  padding: 0 12px;
-  border: 1px solid var(--projects-border);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--projects-text-soft);
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
-.action-row {
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-  flex-wrap: wrap;
-}
-
-.card-open-btn,
-.btn-launch,
-.btn-repo,
-.detail-btn,
-.retry-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 46px;
-  padding: 0 14px;
-  border-radius: 14px;
-  text-decoration: none;
-  font-weight: 700;
-  transition:
-    transform 0.2s ease,
-    border-color 0.2s ease,
-    background 0.2s ease,
-    color 0.2s ease;
-}
-
-.card-open-btn {
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--projects-text);
-  cursor: pointer;
-
-  &:hover {
-    transform: translateX(2px);
-  }
-}
-
-.btn-launch,
-.detail-btn--primary,
-.retry-btn {
-  border: 1px solid rgba(124, 156, 255, 0.22);
-  background: rgba(124, 156, 255, 0.13);
-  color: #eef2ff;
-
-  &:hover {
-    transform: translateY(-1px);
-    background: rgba(124, 156, 255, 0.2);
-  }
-}
-
-.btn-repo,
-.detail-btn--secondary {
-  width: 46px;
-  min-width: 46px;
-  padding: 0;
-  border: 1px solid var(--projects-border);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--projects-text);
-
-  &:hover {
-    transform: translateY(-1px);
-    border-color: var(--projects-border-strong);
-  }
-}
-
-.detail-btn--secondary {
-  width: auto;
-  padding: 0 14px;
-}
-
-.projects-error,
-.projects-empty {
-  max-width: 720px;
-  margin: 80px auto 0;
-  padding: 30px;
-  text-align: center;
-  border: 1px solid var(--projects-border);
-  border-radius: 28px;
-  background: rgba(9, 17, 29, 0.9);
-  box-shadow: var(--projects-shadow);
-}
-
-.error-title,
-.empty-title {
-  margin: 0 0 10px;
-  font-size: 1.5rem;
-  font-weight: 800;
-  letter-spacing: -0.03em;
-}
-
-.retry-btn {
-  margin-top: 18px;
-  border: 0;
-  cursor: pointer;
-}
-
-.drawer-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 39;
-  background: rgba(3, 8, 15, 0.72);
-  backdrop-filter: blur(6px);
-}
-
-.detail-drawer {
-  position: fixed;
-  top: 18px;
-  right: 18px;
-  bottom: 18px;
-  z-index: 40;
-  width: min(520px, calc(100vw - 36px));
-  overflow: auto;
-  border: 1px solid var(--projects-border);
-  border-radius: 28px;
-  background: var(--projects-surface-strong);
-  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.45);
-}
-
-.detail-close {
-  position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 2;
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border: 1px solid var(--projects-border);
-  border-radius: 999px;
-  background: rgba(5, 11, 20, 0.68);
-  color: var(--projects-text);
-  cursor: pointer;
-}
-
-.detail-body {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 24px;
-}
-
-.detail-intro {
-  display: grid;
-  gap: 12px;
-}
-
-.detail-title {
-  margin: 0;
-  font-size: 2rem;
-  line-height: 1;
-  letter-spacing: -0.04em;
-}
-
-.detail-section {
-  display: grid;
-  gap: 12px;
-  padding-top: 18px;
-  border-top: 1px solid var(--projects-border);
-
-  &--meta {
-    gap: 10px;
-  }
-}
-
-.detail-section-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0;
-  color: var(--projects-text);
-  font-size: 1rem;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-}
-
-.detail-meta-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  margin: 0;
-  color: var(--projects-text-soft);
-  line-height: 1.6;
-
-  span {
-    color: var(--projects-text-muted);
-    font-weight: 700;
-  }
-}
-
-.detail-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.skeleton-card {
-  overflow: hidden;
-  animation: skeletonPulse 1.5s ease-in-out infinite;
-
-  &--large {
-    grid-column: span 6;
-  }
-}
-
-.skeleton-media {
-  aspect-ratio: 16 / 10;
-}
-
-.skeleton-body {
-  gap: 12px;
-}
-
-.skel-line {
-  border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0.05) 0%,
-    rgba(255, 255, 255, 0.11) 50%,
-    rgba(255, 255, 255, 0.05) 100%
-  );
-}
-
-.skel-kicker {
-  width: 28%;
-  height: 12px;
-}
-
-.skel-name {
-  width: 62%;
-  height: 22px;
-}
-
-.skel-bio {
-  width: 100%;
-  height: 14px;
-}
-
-.skel-bio-short {
-  width: 78%;
-  height: 14px;
-}
-
-.skel-tag {
-  width: 92px;
-  height: 34px;
-}
-
-.skel-action {
-  width: 132px;
-  height: 44px;
-  margin-top: 8px;
-}
-
-@keyframes skeletonPulse {
-  0%,
-  100% {
-    opacity: 0.72;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
-@media (max-width: 1200px) {
-  .projects-header {
-    grid-template-columns: 1fr;
-  }
-
-  .project-card,
-  .project-card--featured,
-  .skeleton-card,
-  .skeleton-card--large {
-    grid-column: span 6;
-  }
-}
-
-@media (max-width: 900px) {
+@media (max-width: 1080px) {
   .projects-page {
-    padding: 16px;
-  }
-
-  .projects-header,
-  .toolbar-stack {
     padding: 20px;
   }
 
-  .projects-grid {
+  .projects-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .featured-project,
+  .projects-drawer-header {
     grid-template-columns: 1fr;
   }
 
-  .project-card,
-  .project-card--featured,
-  .skeleton-card,
-  .skeleton-card--large {
-    grid-column: span 1;
-  }
-
-  .toolbar-controls {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .search-wrap,
-  .sort-wrap {
-    width: 100%;
-  }
-
-  .search-wrap input,
-  .sort-wrap select {
-    width: 100%;
-  }
-
-  .toolbar-top,
-  .action-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .action-links {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .card-open-btn,
-  .btn-launch {
-    width: 100%;
-  }
-
-  .btn-repo {
-    width: 46px;
-  }
-
-  .detail-drawer {
-    top: 12px;
-    right: 12px;
-    bottom: 12px;
-    width: calc(100vw - 24px);
+  .projects-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 640px) {
-  .page-title {
-    max-width: 100%;
+@media (max-width: 700px) {
+  .projects-grid,
+  .projects-toolbar {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1100px) {
+  .projects-page {
+    padding: 32px;
   }
 
-  .proof-chips,
-  .tech-filter,
-  .filter-bar {
-    gap: 8px;
-  }
-
-  .filter-btn,
-  .view-toggle-btn,
-  .tech-chip,
-  .clear-btn {
-    min-height: 38px;
-    padding: 0 12px;
-    font-size: 0.84rem;
-  }
-
-  .project-name {
-    font-size: 1.25rem;
-  }
-
-  .detail-title {
-    font-size: 1.6rem;
+  .projects-shell {
+    gap: 32px;
   }
 }

--- a/client/tests/projects.test.js
+++ b/client/tests/projects.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import {
+  applyProjectFilters,
+  getCaseStudy,
+  getProjectTags,
+  normalizeStatus,
+} from "../src/Pages/Projects/projectUtils";
+
+const projects = [
+  {
+    id: 1,
+    name: "Zeta",
+    status: "Active",
+    featured: false,
+    features: ["React", "Node"],
+    description: "alpha search",
+  },
+  {
+    id: 2,
+    name: "Alpha",
+    status: "Building",
+    featured: true,
+    features: ["MongoDB", "React"],
+    description: "case study app",
+    challenge: "Messy data",
+    approach: "Normalized payload",
+    outcome: "Shipped",
+  },
+];
+
+describe("projects page data behavior", () => {
+  it("normalizes status buckets", () => {
+    expect(normalizeStatus("live")).toBe("active");
+    expect(normalizeStatus("WIP")).toBe("building");
+    expect(normalizeStatus("archived")).toBe("archived");
+  });
+
+  it("returns max 12 sorted tags", () => {
+    const tags = getProjectTags([
+      ...projects,
+      { features: ["TypeScript", "Express", "Docker", "Redis", "Jest", "Vite", "Tailwind", "CI", "CD", "GraphQL", "Prisma", "K8s", "Sentry"] },
+    ]);
+
+    expect(tags.length).toBe(12);
+    expect(tags[0]).toBe("CD");
+  });
+
+  it("applies featured sort then filter logic", () => {
+    const result = applyProjectFilters({
+      projects,
+      statusFilter: "All",
+      sortBy: "Featured",
+      search: "",
+      activeTags: [],
+    });
+
+    expect(result[0].name).toBe("Alpha");
+  });
+
+  it("applies search and tags", () => {
+    const result = applyProjectFilters({
+      projects,
+      statusFilter: "All",
+      sortBy: "Featured",
+      search: "case",
+      activeTags: ["MongoDB"],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Alpha");
+  });
+
+  it("maps case study fields", () => {
+    expect(getCaseStudy(projects[1])).toEqual({
+      problem: "Messy data",
+      solution: "Normalized payload",
+      outcome: "Shipped",
+    });
+  });
+
+  it("uses TanStack hook instead of direct fetch in page", () => {
+    const projectsPage = fs.readFileSync("src/Pages/Projects/Projects.jsx", "utf-8");
+
+    expect(projectsPage.includes("useProjects()") || projectsPage.includes("useProjects("))
+      .toBe(true);
+    expect(projectsPage.includes("fetch(")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement the portfolio redesign spec: overview-first, depth-on-demand while preserving left-side nav behavior and current backend data shape.
- Reduce visual clutter and improve scanability by consolidating controls and separating overview from detail.
- Make the new UX implementable without API changes by keeping the existing data model and adopting TanStack Query for fetching.

### Description
- Rebuilt `client/src/Pages/Projects/Projects.jsx` to add a compact intro, a split featured section, a single control bar (search/status/sort/view/filter), a collapsible filter drawer, an active filter summary, Grid and Case Study modes, and a project detail drawer with ESC-to-close and keyboard focus trap.
- Extracted filtering/sorting/status/case-study helpers into `client/src/Pages/Projects/projectUtils.js`, and replaced in-component `fetch` usage with the `useProjects` TanStack Query hook.
- Reworked visuals in `client/src/Pages/Projects/projects.styles.scss` to a cleaner, lower-noise layout constrained to a max width of `1280px`, with responsive spacing and 1/2/3 column grid behavior and reduced gradients/glow.
- Added unit tests in `client/tests/projects.test.js` to cover status normalization, tag extraction (max 12), filtering/sorting behavior, case-study mapping, and to assert the page uses `useProjects` rather than direct `fetch`.
- No external skills were used — changes implemented directly in the repository.

### Testing
- Ran `npm test -- --run tests/projects.test.js tests/settings.test.js` from the `client/` directory and the test run completed successfully.
- Automated test result: 2 test files executed (`projects.test.js`, `settings.test.js`) and 9 tests passed (9/9).
- The tests validate filtering, sorting, tag limits, case-study field mapping, and that `useProjects` is used instead of `fetch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41be811e483309256bfb109d17fe4)