### PR TITLE
Admin: add message details page, API endpoint, and dashboard navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,7 @@ import Contact from "./Pages/Contact/Contact";
 import AdminRoute from "./components/AdminRoute/AdminRoute";
 import AdminLogin from "./Pages/Login/AdminLogin";
 import AdminDashboard from "./Pages/AdminDashboard/AdminDashboard";
+import AdminMessageDetails from "./Pages/AdminMessageDetails/AdminMessageDetails";
 import useAdminSession from "./hooks/queries/useAdminSession";
 
 const PublicLayout = () => {
@@ -52,6 +53,7 @@ const App = () => {
         <Route path="/admin/login" element={<AdminLogin />} />
         <Route element={<AdminRoute />}>
           <Route path="/admin/dashboard" element={<AdminDashboard />} />
+          <Route path="/admin/messages/:messageId" element={<AdminMessageDetails />} />
         </Route>
       </Routes>
     </Router>

--- a/client/src/Pages/AdminDashboard/AdminDashboard.jsx
+++ b/client/src/Pages/AdminDashboard/AdminDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import useContactMessages from '../../hooks/queries/useContactMessages';
 import useNewsletterSubscribers from '../../hooks/queries/useNewsletterSubscribers';
 import useLogoutAdmin from '../../hooks/mutations/useLogoutAdmin';
@@ -27,6 +28,7 @@ const Pagination = ({ page, total, limit, onPrev, onNext }) => {
 };
 
 const ContactMessagesTab = () => {
+  const navigate = useNavigate();
   const [page, setPage] = useState(1);
   const { data, isLoading } = useContactMessages(page);
   const { messages = [], total = 0, limit = 20 } = data?.data?.data || {};
@@ -52,7 +54,16 @@ const ContactMessagesTab = () => {
               <tr key={msg._id}>
                 <td>{msg.name}</td>
                 <td className={s.cellMuted}>{msg.email}</td>
-                <td>{msg.subject}</td>
+                <td>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/admin/messages/${msg._id}`)}
+                    className={s.subjectBtn}
+                    aria-label={`View message from ${msg.name}`}
+                  >
+                    {msg.subject || 'No subject'}
+                  </button>
+                </td>
                 <td className={s.cellTruncate} title={msg.message}>{msg.message}</td>
                 <td className={s.cellMono}>{new Date(msg.createdAt).toLocaleDateString()}</td>
               </tr>

--- a/client/src/Pages/AdminDashboard/AdminDashboard.module.scss
+++ b/client/src/Pages/AdminDashboard/AdminDashboard.module.scss
@@ -200,6 +200,26 @@ $lime-dim: #84cc16;
   white-space: nowrap;
 }
 
+.subjectBtn {
+  color: $text-main;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    color: $lime;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $lime;
+    outline-offset: 3px;
+    border-radius: 4px;
+  }
+}
+
 // ── Empty / spinner ───────────────────────────────────────────────────────────
 
 .empty {

--- a/client/src/Pages/AdminMessageDetails/AdminMessageDetails.jsx
+++ b/client/src/Pages/AdminMessageDetails/AdminMessageDetails.jsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import useContactMessage from '../../hooks/queries/useContactMessage';
+import s from './AdminMessageDetails.module.scss';
+
+const formatDateTime = (dateString) => {
+  if (!dateString) {
+    return '—';
+  }
+
+  return new Date(dateString).toLocaleString();
+};
+
+const AdminMessageDetails = () => {
+  const { messageId } = useParams();
+  const [copyState, setCopyState] = useState('');
+  const { data, isLoading, isError, error, refetch, isFetching } = useContactMessage(messageId);
+
+  const message = data?.data?.data?.message;
+  const isNotFound = error?.response?.status === 404 || error?.response?.status === 400;
+
+  const mailtoHref = useMemo(() => {
+    if (!message?.email) {
+      return '#';
+    }
+
+    const subject = encodeURIComponent(`Re: ${message.subject || 'No subject'}`);
+    return `mailto:${message.email}?subject=${subject}`;
+  }, [message?.email, message?.subject]);
+
+  const handleCopy = async (value, label) => {
+    if (!value || !navigator?.clipboard?.writeText) {
+      setCopyState(`Unable to copy ${label.toLowerCase()}`);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState(`${label} copied`);
+      setTimeout(() => setCopyState(''), 1800);
+    } catch {
+      setCopyState(`Unable to copy ${label.toLowerCase()}`);
+    }
+  };
+
+  if (isLoading || isFetching) {
+    return (
+      <div className={s.page}>
+        <main className={s.main}>
+          <div className={s.card}>
+            <p className={s.muted}>Loading message details…</p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (isError && isNotFound) {
+    return (
+      <div className={s.page}>
+        <main className={s.main}>
+          <div className={s.card}>
+            <h1 className={s.title}>Message not found</h1>
+            <p className={s.muted}>The link is invalid or the message no longer exists.</p>
+            <Link className={s.backBtn} to="/admin/dashboard">Back to dashboard</Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className={s.page}>
+        <main className={s.main}>
+          <div className={s.card}>
+            <h1 className={s.title}>Unable to load message</h1>
+            <p className={s.muted}>Please try again.</p>
+            <div className={s.actions}>
+              <button type="button" onClick={() => refetch()} className={s.actionBtn}>Retry</button>
+              <Link className={s.backBtn} to="/admin/dashboard">Back to dashboard</Link>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className={s.page}>
+      <main className={s.main}>
+        <header className={s.header}>
+          <Link className={s.backBtn} to="/admin/dashboard">← Back to dashboard</Link>
+          <h1 className={s.title}>Message Details</h1>
+          <span className={s.statusBadge}>
+            {message?.isRead ? 'Read' : 'Unread'}
+          </span>
+        </header>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Sender</h2>
+          <dl className={s.metaGrid}>
+            <div>
+              <dt>Name</dt>
+              <dd>{message?.name || '—'}</dd>
+            </div>
+            <div>
+              <dt>Email</dt>
+              <dd>{message?.email || '—'}</dd>
+            </div>
+            <div>
+              <dt>Sent</dt>
+              <dd>{formatDateTime(message?.createdAt)}</dd>
+            </div>
+            <div>
+              <dt>Read status</dt>
+              <dd>
+                {message?.isRead ? 'Read' : 'Unread'}
+                {message?.readAt ? ` · ${formatDateTime(message.readAt)}` : ''}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Subject</h2>
+          <p className={s.subject}>{message?.subject || 'No subject'}</p>
+        </section>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Message</h2>
+          <p className={s.body}>{message?.message || 'No message content.'}</p>
+        </section>
+
+        <section className={s.card}>
+          <h2 className={s.sectionTitle}>Actions</h2>
+          <div className={s.actions}>
+            <a href={mailtoHref} className={s.actionBtn}>Reply</a>
+            <button
+              type="button"
+              className={s.actionBtn}
+              onClick={() => handleCopy(message?.email, 'Email')}
+            >
+              Copy email
+            </button>
+            <button
+              type="button"
+              className={s.actionBtn}
+              onClick={() => handleCopy(message?.message, 'Message')}
+            >
+              Copy message
+            </button>
+          </div>
+          {copyState ? <p className={s.copyFeedback}>{copyState}</p> : null}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default AdminMessageDetails;

--- a/client/src/Pages/AdminMessageDetails/AdminMessageDetails.module.scss
+++ b/client/src/Pages/AdminMessageDetails/AdminMessageDetails.module.scss
@@ -1,0 +1,130 @@
+$bg-main: #09090b;
+$bg-surface: #111113;
+$bg-card: #18181b;
+$border: #27272a;
+$text-main: #fafafa;
+$text-muted: #a1a1aa;
+$lime: #a3e635;
+
+.page {
+  min-height: 100vh;
+  background-color: $bg-main;
+  color: $text-main;
+}
+
+.main {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.statusBadge {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: $lime;
+  border: 1px solid rgba(163, 230, 53, 0.35);
+  background: rgba(163, 230, 53, 0.1);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.card {
+  background-color: $bg-card;
+  border: 1px solid $border;
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.sectionTitle {
+  margin: 0 0 0.7rem;
+  font-size: 0.9rem;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+
+  dt {
+    font-size: 0.75rem;
+    color: $text-muted;
+    margin-bottom: 0.25rem;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.92rem;
+  }
+}
+
+.subject {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  margin: 0;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.actionBtn,
+.backBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: 1px solid $border;
+  background: $bg-surface;
+  color: $text-main;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.85rem;
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #52525b;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $lime;
+    outline-offset: 2px;
+  }
+}
+
+.muted {
+  margin: 0;
+  color: $text-muted;
+}
+
+.copyFeedback {
+  margin: 0.75rem 0 0;
+  color: $lime;
+  font-size: 0.82rem;
+}

--- a/client/src/hooks/queries/useContactMessage.js
+++ b/client/src/hooks/queries/useContactMessage.js
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { getContactMessageById } from '../../services/adminService';
+
+const useContactMessage = (messageId) => {
+  const admin = useSelector((state) => state.auth.admin);
+
+  return useQuery({
+    queryKey: ['contactMessage', messageId],
+    queryFn: () => getContactMessageById(messageId),
+    enabled: !!admin && !!messageId,
+    retry: false,
+  });
+};
+
+export default useContactMessage;

--- a/client/src/services/adminService.js
+++ b/client/src/services/adminService.js
@@ -12,5 +12,8 @@ export const getAdminSession = () =>
 export const getContactMessages = (page = 1, limit = 20) =>
   api.get('/api/admin/contact-messages', { params: { page, limit } });
 
+export const getContactMessageById = (messageId) =>
+  api.get(`/api/admin/contact-messages/${messageId}`);
+
 export const getNewsletterSubscribers = (page = 1, limit = 20) =>
   api.get('/api/admin/newsletter-subscribers', { params: { page, limit } });

--- a/client/test/admin/AdminDashboard.test.jsx
+++ b/client/test/admin/AdminDashboard.test.jsx
@@ -4,9 +4,9 @@ import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import authReducer from '../../src/redux/auth/authSlice';
-import AdminDashboard from '../../src/pages/AdminDashboard/AdminDashboard';
+import AdminDashboard from '../../src/Pages/AdminDashboard/AdminDashboard';
 
 vi.mock('../../src/hooks/queries/useContactMessages');
 vi.mock('../../src/hooks/queries/useNewsletterSubscribers');
@@ -30,8 +30,11 @@ const renderDashboard = () => {
   return render(
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <AdminDashboard />
+        <MemoryRouter initialEntries={['/admin/dashboard']}>
+          <Routes>
+            <Route path="/admin/dashboard" element={<AdminDashboard />} />
+            <Route path="/admin/messages/:messageId" element={<p>Message details route</p>} />
+          </Routes>
         </MemoryRouter>
       </QueryClientProvider>
     </Provider>
@@ -62,7 +65,21 @@ describe('AdminDashboard — Contact Messages tab', () => {
 
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('alice@test.com')).toBeInTheDocument();
-    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view message from alice/i })).toBeInTheDocument();
+  });
+
+  it('navigates to details route when subject button is clicked', () => {
+    useContactMessages.mockReturnValue({
+      data: { data: { data: { messages: mockMessages, total: 1, limit: 20 } } },
+      isLoading: false,
+    });
+    useNewsletterSubscribers.mockReturnValue({ data: null, isLoading: false });
+
+    renderDashboard();
+
+    fireEvent.click(screen.getByRole('button', { name: /view message from alice/i }));
+
+    expect(screen.getByText('Message details route')).toBeInTheDocument();
   });
 
   it('shows empty state when messages array is empty', () => {

--- a/client/test/admin/AdminMessageDetails.test.jsx
+++ b/client/test/admin/AdminMessageDetails.test.jsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import authReducer from '../../src/redux/auth/authSlice';
+import AdminMessageDetails from '../../src/Pages/AdminMessageDetails/AdminMessageDetails';
+
+vi.mock('../../src/hooks/queries/useContactMessage');
+
+import useContactMessage from '../../src/hooks/queries/useContactMessage';
+
+const ADMIN = { email: 'admin@devkofi.com', role: 'admin' };
+
+const makeStore = () =>
+  configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: { auth: { admin: ADMIN, isChecked: true } },
+  });
+
+const renderPage = () => {
+  const store = makeStore();
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/admin/messages/123']}>
+          <Routes>
+            <Route path="/admin/messages/:messageId" element={<AdminMessageDetails />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </Provider>
+  );
+};
+
+describe('AdminMessageDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+  });
+
+  it('shows loading state while request is pending', () => {
+    useContactMessage.mockReturnValue({ isLoading: true, isFetching: false });
+
+    renderPage();
+
+    expect(screen.getByText(/loading message details/i)).toBeInTheDocument();
+  });
+
+  it('renders message details and actions', () => {
+    useContactMessage.mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      data: {
+        data: {
+          data: {
+            message: {
+              _id: '123',
+              name: 'Alice',
+              email: 'alice@test.com',
+              subject: 'Need help',
+              message: 'Line one\nLine two',
+              createdAt: '2026-04-20T00:00:00.000Z',
+              isRead: false,
+              readAt: null,
+            },
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Message Details')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Need help')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /reply/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('mailto:alice@test.com?subject=Re%3A%20Need%20help')
+    );
+  });
+
+  it('shows not found state for 404', () => {
+    useContactMessage.mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: { response: { status: 404 } },
+    });
+
+    renderPage();
+
+    expect(screen.getByText(/message not found/i)).toBeInTheDocument();
+  });
+
+  it('copies email to clipboard', async () => {
+    useContactMessage.mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      data: {
+        data: {
+          data: {
+            message: {
+              _id: '123',
+              name: 'Alice',
+              email: 'alice@test.com',
+              subject: 'Need help',
+              message: 'Line one\nLine two',
+              createdAt: '2026-04-20T00:00:00.000Z',
+              isRead: false,
+              readAt: null,
+            },
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy email/i }));
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('alice@test.com');
+  });
+});

--- a/server/controllers/adminDashboardController.js
+++ b/server/controllers/adminDashboardController.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const ContactMessage = require('../models/ContactMessage');
 const NewsletterSubscriber = require('../models/NewsletterSubscriber');
 
@@ -22,6 +23,31 @@ const getContactMessages = async (req, res) => {
   });
 };
 
+const getContactMessageById = async (req, res) => {
+  const { messageId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(messageId)) {
+    return res.status(400).json({
+      success: false,
+      error: 'Invalid message id',
+    });
+  }
+
+  const message = await ContactMessage.findById(messageId);
+
+  if (!message) {
+    return res.status(404).json({
+      success: false,
+      error: 'Message not found',
+    });
+  }
+
+  return res.status(200).json({
+    success: true,
+    data: { message },
+  });
+};
+
 const getNewsletterSubscribers = async (req, res) => {
   const { page, limit, skip } = parsePagination(req.query);
 
@@ -36,4 +62,4 @@ const getNewsletterSubscribers = async (req, res) => {
   });
 };
 
-module.exports = { getContactMessages, getNewsletterSubscribers };
+module.exports = { getContactMessages, getContactMessageById, getNewsletterSubscribers };

--- a/server/models/ContactMessage.js
+++ b/server/models/ContactMessage.js
@@ -6,6 +6,8 @@ const contactMessageSchema = new mongoose.Schema(
     email: { type: String, required: true, lowercase: true, trim: true },
     subject: { type: String, required: true, trim: true },
     message: { type: String, required: true, trim: true },
+    isRead: { type: Boolean, default: false },
+    readAt: { type: Date, default: null },
   },
   { timestamps: true }
 );

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
 const { loginAdmin, logoutAdmin, getAdminSession } = require('../controllers/adminAuthController');
-const { getContactMessages, getNewsletterSubscribers } = require('../controllers/adminDashboardController');
+const {
+  getContactMessages,
+  getContactMessageById,
+  getNewsletterSubscribers,
+} = require('../controllers/adminDashboardController');
 const requireAdminAuth = require('../middleware/requireAdminAuth');
 const { loginRateLimit } = require('../config/env');
 
@@ -19,6 +23,7 @@ router.post('/auth/login', loginLimiter, loginAdmin);
 router.post('/auth/logout', logoutAdmin);
 router.get('/auth/me', requireAdminAuth, getAdminSession);
 router.get('/contact-messages', requireAdminAuth, getContactMessages);
+router.get('/contact-messages/:messageId', requireAdminAuth, getContactMessageById);
 router.get('/newsletter-subscribers', requireAdminAuth, getNewsletterSubscribers);
 
 module.exports = router;

--- a/server/tests/admin.test.js
+++ b/server/tests/admin.test.js
@@ -8,6 +8,7 @@ const NewsletterSubscriber = require('../models/NewsletterSubscriber');
 
 const TEST_EMAIL = 'testadmin@devkofi.com';
 const TEST_PASSWORD = 'TestAdmin@2026!';
+let testMessageId;
 
 beforeAll(async () => {
   const uri = process.env.MONGO_URI;
@@ -19,12 +20,14 @@ beforeAll(async () => {
   await Admin.deleteMany({ email: TEST_EMAIL });
   await Admin.create({ email: TEST_EMAIL, password: hash, role: 'admin' });
 
-  await ContactMessage.create({
+  const seededMessage = await ContactMessage.create({
     name: 'Alice',
     email: 'alice@test.com',
     subject: 'Hello',
     message: 'Test message',
   });
+  testMessageId = seededMessage._id.toString();
+
   await NewsletterSubscriber.create({ email: 'subscriber@test.com' });
 });
 
@@ -132,6 +135,50 @@ describe('GET /api/admin/contact-messages', () => {
   it('returns 401 when unauthenticated', async () => {
     const res = await request(app).get('/api/admin/contact-messages');
     expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/admin/contact-messages/:messageId', () => {
+  it('returns 200 with a single message when authenticated', async () => {
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get(`/api/admin/contact-messages/${testMessageId}`)
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('message');
+    expect(res.body.data.message._id).toBe(testMessageId);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get(`/api/admin/contact-messages/${testMessageId}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 400 for invalid object id', async () => {
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get('/api/admin/contact-messages/not-a-valid-id')
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Invalid message id');
+  });
+
+  it('returns 404 for a valid id that does not exist', async () => {
+    const cookie = await getAuthCookie();
+    const missingId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .get(`/api/admin/contact-messages/${missingId}`)
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Message not found');
   });
 });
 


### PR DESCRIPTION
### Motivation

- Provide a dedicated admin view to inspect individual contact messages and enable quick reply/copy actions. 
- Expose a server API to fetch a single contact message by id and surface read metadata for message management. 
- Allow navigating from the dashboard message list into the new details view.

### Description

- Added a new page component `AdminMessageDetails` and stylesheet `AdminMessageDetails.module.scss` to display sender metadata, subject, message body, and actions (`Reply`, `Copy email`, `Copy message`).
- Implemented a new React Query hook `useContactMessage` and added `getContactMessageById` to `adminService.js` to fetch a message by id. 
- Wired the client routes: registered `/admin/messages/:messageId` in `App.jsx` and updated the dashboard list so the subject is a button that navigates to the details route via `useNavigate` and added `.subjectBtn` styles.
- Extended the server: added `getContactMessageById` to `adminDashboardController`, registered route `GET /api/admin/contact-messages/:messageId`, and added `isRead`/`readAt` fields to the `ContactMessage` model.
- Updated tests: adapted `AdminDashboard.test.jsx` to assert navigation and subject button behavior and added `AdminMessageDetails.test.jsx` client tests; extended `server/tests/admin.test.js` with integration tests for the new single-message endpoint.

### Testing

- Ran client unit/RTL tests with Vitest for `AdminDashboard` and the new `AdminMessageDetails`, which include UI assertions and clipboard behavior, and they passed.
- Ran server integration tests (Supertest) in `server/tests/admin.test.js` exercising `GET /api/admin/contact-messages/:messageId` for success, auth failure, invalid id, and not-found scenarios, and they passed.
- Confirmed existing admin dashboard pagination/subscriber tests still run under the updated test harness and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94dd66e9483309c23213c825edcc9)