### PR TITLE
Add admin newsletter export (CSV/JSON) with UI, routes, and tests

### DIFF
--- a/_plan/newsletter-export-plan.md
+++ b/_plan/newsletter-export-plan.md
@@ -1,0 +1,310 @@
+# Newsletter Subscribers Export Feature – Full Implementation Plan
+
+**Spec:** Newsletter Subscribers Export Feature – Implementation Spec  
+**Date:** 2026-04-22  
+**Stack:** MERN (React + Vite, Node/Express, MongoDB, TanStack Query, Redux Toolkit)
+
+---
+
+## 1) Scope + Acceptance Mapping
+
+### Required outcomes
+- Admin can export newsletter subscribers from Admin Dashboard → Newsletter Subscribers tab.
+- Two formats: CSV and JSON.
+- Export includes fields: `email`, `subscribedAt` (`createdAt` alias).
+- Export endpoints are admin-auth protected.
+- UX supports idle/loading/error states.
+
+### Direct acceptance criteria mapping
+- **Export button visible** → Add dropdown button in newsletter tab UI.
+- **CSV + JSON download works** → Add API service calls + blob download helper.
+- **Files contain correct data** → Backend sort/transform/headers verified in tests.
+- **Protected routes** → `requireAdminAuth` middleware on export routes.
+- **Handles empty state** → CSV header-only + JSON empty array.
+- **Shows loading + error states** → per-format loading flags + toast/error message.
+
+---
+
+## 2) Current Codebase Fit (What already exists)
+
+- Admin auth + middleware already implemented (`requireAdminAuth`).
+- Admin dashboard route set already mounted under `/api/admin`.
+- Newsletter subscriber list endpoint exists with pagination.
+- Admin dashboard newsletter tab exists in `client/src/Pages/AdminDashboard/AdminDashboard.jsx`.
+- API layer (`client/src/services/adminService.js`) already centralizes admin requests.
+- Backend Jest tests exist in `server/tests/admin.test.js` and can be extended.
+
+This means the feature can be added incrementally without architecture changes.
+
+---
+
+## 3) Backend Plan
+
+### Phase B1 — Add shared export transformer utilities
+
+**Files**
+- `server/controllers/adminDashboardController.js` (or extract to `server/utils/newsletterExport.js`)
+
+**Changes**
+- Add transformation helper:
+  - Input: `NewsletterSubscriber[]`
+  - Output shape:
+    - `{ email: string, subscribedAt: string }`
+  - `subscribedAt = createdAt.toISOString()`
+- Keep transformation centralized to ensure CSV/JSON parity.
+
+**Done when**
+- One source of truth for export row mapping exists.
+
+---
+
+### Phase B2 — Implement JSON export controller
+
+**Files**
+- `server/controllers/adminDashboardController.js`
+
+**New handler**
+- `exportNewsletterSubscribersJson(req, res)`
+
+**Behavior**
+1. Query all subscribers sorted by `createdAt: -1`.
+2. Transform to export shape.
+3. Build filename: `newsletter-subscribers-YYYY-MM-DD.json` (UTC date).
+4. Set headers:
+   - `Content-Type: application/json; charset=utf-8`
+   - `Content-Disposition: attachment; filename="..."`
+5. Return JSON payload.
+
+**Edge handling**
+- Empty list returns `[]`.
+
+**Done when**
+- Endpoint responds with downloadable attachment and correct payload.
+
+---
+
+### Phase B3 — Implement CSV export controller
+
+**Files**
+- `server/controllers/adminDashboardController.js`
+
+**New handler**
+- `exportNewsletterSubscribersCsv(req, res)`
+
+**Behavior**
+1. Query all subscribers sorted by `createdAt: -1`.
+2. Transform via shared helper.
+3. Build CSV string:
+   - Header row: `email,subscribedAt`
+   - Data rows in sorted order.
+4. Escape CSV safely:
+   - Wrap values with quotes when needed.
+   - Escape inner quotes.
+5. Build filename: `newsletter-subscribers-YYYY-MM-DD.csv`.
+6. Set headers:
+   - `Content-Type: text/csv; charset=utf-8`
+   - `Content-Disposition: attachment; filename="..."`
+7. Send raw CSV text.
+
+**Edge handling**
+- Empty list returns only header row + newline.
+
+**Done when**
+- CSV opens cleanly in spreadsheet tools and matches spec.
+
+---
+
+### Phase B4 — Register new protected routes
+
+**Files**
+- `server/routes/adminRoutes.js`
+
+**Add routes (protected)**
+- `GET /newsletter/export/csv` → `requireAdminAuth` + CSV handler
+- `GET /newsletter/export/json` → `requireAdminAuth` + JSON handler
+
+**Done when**
+- Routes are reachable only with admin auth.
+
+---
+
+### Phase B5 — Backend Jest coverage
+
+**Files**
+- `server/tests/admin.test.js`
+
+**Add tests**
+1. `GET /api/admin/newsletter/export/csv` authenticated:
+   - status `200`
+   - `Content-Type` includes `text/csv`
+   - `Content-Disposition` includes `.csv`
+   - body contains header `email,subscribedAt`
+2. `GET /api/admin/newsletter/export/json` authenticated:
+   - status `200`
+   - `Content-Type` includes `application/json`
+   - `Content-Disposition` includes `.json`
+   - response array rows contain `email` + `subscribedAt`
+3. Unauthorized checks (both endpoints):
+   - no cookie → `401`
+4. Empty list behavior:
+   - clear `NewsletterSubscriber` collection for test case
+   - CSV returns header only
+   - JSON returns `[]`
+
+**Done when**
+- Tests validate type, filename, auth, empty behavior.
+
+---
+
+## 4) Frontend Plan
+
+### Phase F1 — Add export API methods (service layer only)
+
+**Files**
+- `client/src/services/adminService.js`
+
+**Add methods**
+- `exportNewsletterSubscribersCsv()`
+- `exportNewsletterSubscribersJson()`
+
+**Implementation detail**
+- Use `api.get(url, { responseType: 'blob' })`.
+- Keep API logic outside components.
+
+**Done when**
+- Components call service methods only.
+
+---
+
+### Phase F2 — Add download helper utility
+
+**Files**
+- `client/src/utils/downloadFile.js` (new)
+
+**Utility behavior**
+- Accepts `{ blob, filename }`
+- Creates object URL, triggers hidden anchor click, revokes URL.
+
+**Done when**
+- Download trigger logic is reusable and isolated from UI component complexity.
+
+---
+
+### Phase F3 — Add export UI controls + states
+
+**Files**
+- `client/src/Pages/AdminDashboard/AdminDashboard.jsx`
+- `client/src/Pages/AdminDashboard/AdminDashboard.module.scss` (existing) or migrate this part to Tailwind classes in JSX if preferred
+
+**UI changes (Newsletter tab)**
+- Add “Export” button with dropdown items:
+  - Export CSV
+  - Export JSON
+- Add local state:
+  - `isExportMenuOpen`
+  - `isExportingCsv`
+  - `isExportingJson`
+  - optional `exportError`
+- Disable corresponding option while exporting.
+- Button label while exporting: `Exporting...`.
+
+**Behavior**
+1. Click CSV/JSON option.
+2. Call corresponding service method.
+3. Read filename from `Content-Disposition`; fallback to generated local filename.
+4. Pass blob + filename to download utility.
+5. On failure, show toast/message and keep UI responsive.
+
+**Done when**
+- Export is one-click from menu, with loading and error feedback.
+
+---
+
+### Phase F4 — Frontend Vitest tests
+
+**Files**
+- `client/src/Pages/AdminDashboard/AdminDashboard.test.jsx` (new or extend existing test suite)
+
+**Add tests**
+1. Export controls render in newsletter tab.
+2. Clicking CSV triggers service call and download helper.
+3. Clicking JSON triggers service call and download helper.
+4. Error path shows message/toast.
+5. Loading state disables option and updates label.
+
+**Test strategy**
+- Mock `adminService` export methods.
+- Mock `downloadFile` utility.
+- Use Testing Library with async assertions.
+
+**Done when**
+- Required frontend behaviors are covered and deterministic.
+
+---
+
+## 5) Data + Formatting Rules
+
+### Sort order
+- Always `createdAt DESC` before transform/export.
+
+### Field mapping
+- `email` → passthrough.
+- `subscribedAt` → `createdAt.toISOString()`.
+
+### File naming
+- CSV: `newsletter-subscribers-YYYY-MM-DD.csv`
+- JSON: `newsletter-subscribers-YYYY-MM-DD.json`
+- Date source: server-side UTC date for consistency.
+
+### Content types
+- CSV: `text/csv; charset=utf-8`
+- JSON: `application/json; charset=utf-8`
+
+---
+
+## 6) Error Handling + Security
+
+### Security
+- Reuse `requireAdminAuth` on both export routes.
+- No public access path for exports.
+
+### Backend error handling
+- If DB/query fails, return consistent server error response shape (existing pattern).
+
+### Frontend error handling
+- Show toast or inline error text on export failure.
+- Reset loading flags in `finally` block.
+
+---
+
+## 7) Execution Order (TDD-first)
+
+1. **Backend tests first** for new CSV/JSON export endpoints + unauthorized + empty states.
+2. Implement backend controllers/routes until tests pass.
+3. **Frontend tests next** for export actions/loading/errors.
+4. Implement service + utility + dashboard UI until tests pass.
+5. Run full test suite and do manual verification from admin dashboard.
+
+---
+
+## 8) Definition of Done Checklist
+
+- [ ] `GET /api/admin/newsletter/export/csv` implemented + admin-protected.
+- [ ] `GET /api/admin/newsletter/export/json` implemented + admin-protected.
+- [ ] Output sorted by newest subscriber first.
+- [ ] CSV headers exactly `email,subscribedAt`.
+- [ ] JSON shape exactly array of `{ email, subscribedAt }`.
+- [ ] Empty export behavior implemented (CSV header-only, JSON `[]`).
+- [ ] Admin dashboard newsletter tab has export dropdown with CSV/JSON options.
+- [ ] Loading and error states implemented in UI.
+- [ ] Backend Jest tests added and passing.
+- [ ] Frontend Vitest tests added and passing.
+
+---
+
+## 9) Optional Enhancements (post-MVP)
+
+- Stream CSV response for very large datasets.
+- Add audit log entry for export actions (admin id + timestamp).
+- Add optional date-range filters before exporting.
+- Add e2e test (Playwright) to verify browser download UX.

--- a/client/src/Pages/AdminDashboard/AdminDashboard.jsx
+++ b/client/src/Pages/AdminDashboard/AdminDashboard.jsx
@@ -1,8 +1,14 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useMutation } from '@tanstack/react-query';
 import useContactMessages from '../../hooks/queries/useContactMessages';
 import useNewsletterSubscribers from '../../hooks/queries/useNewsletterSubscribers';
 import useLogoutAdmin from '../../hooks/mutations/useLogoutAdmin';
+import {
+  exportNewsletterSubscribersCsv,
+  exportNewsletterSubscribersJson,
+} from '../../services/adminService';
+import downloadFile, { getFilenameFromDisposition } from '../../utils/downloadFile';
 import s from './AdminDashboard.module.scss';
 
 const TABS = ['Contact Messages', 'Newsletter Subscribers'];
@@ -70,36 +76,123 @@ const ContactMessagesTab = () => {
 
 const NewsletterSubscribersTab = () => {
   const [page, setPage] = useState(1);
+  const [isExportMenuOpen, setIsExportMenuOpen] = useState(false);
+  const [exportError, setExportError] = useState('');
   const { data, isLoading } = useNewsletterSubscribers(page);
   const { subscribers = [], total = 0, limit = 20 } = data?.data?.data || {};
 
+  const csvMutation = useMutation({
+    mutationFn: exportNewsletterSubscribersCsv,
+  });
+
+  const jsonMutation = useMutation({
+    mutationFn: exportNewsletterSubscribersJson,
+  });
+
+  const isExporting = csvMutation.isPending || jsonMutation.isPending;
+
+  const exportActions = useMemo(
+    () => ({
+      csv: {
+        fallbackName: `newsletter-subscribers-${new Date().toISOString().slice(0, 10)}.csv`,
+        run: csvMutation.mutateAsync,
+      },
+      json: {
+        fallbackName: `newsletter-subscribers-${new Date().toISOString().slice(0, 10)}.json`,
+        run: jsonMutation.mutateAsync,
+      },
+    }),
+    [csvMutation.mutateAsync, jsonMutation.mutateAsync]
+  );
+
+  const handleExport = async (format) => {
+    setExportError('');
+
+    try {
+      const action = exportActions[format];
+      const response = await action.run();
+      const filename = getFilenameFromDisposition(
+        response.headers?.['content-disposition'],
+        action.fallbackName
+      );
+
+      downloadFile({ blob: response.data, filename });
+      setIsExportMenuOpen(false);
+    } catch {
+      setExportError('Export failed. Please try again.');
+    }
+  };
+
   if (isLoading) return <Spinner />;
-  if (!subscribers.length) return <p className={s.empty}>No subscribers yet</p>;
 
   return (
     <>
-      <div className={s.tableWrapper}>
-        <table className={s.table}>
-          <thead className={s.thead}>
-            <tr>
-              <th>Email</th>
-              <th>Subscribed</th>
-            </tr>
-          </thead>
-          <tbody className={s.tbody}>
-            {subscribers.map((sub) => (
-              <tr key={sub._id}>
-                <td>{sub.email}</td>
-                <td className={s.cellMono}>{new Date(sub.createdAt).toLocaleDateString()}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className={s.exportRow}>
+        <div className={s.exportWrap}>
+          <button
+            type="button"
+            onClick={() => setIsExportMenuOpen((open) => !open)}
+            className={s.exportBtn}
+            disabled={isExporting}
+          >
+            {isExporting ? 'Exporting...' : 'Export'}
+          </button>
+
+          {isExportMenuOpen && (
+            <div className={s.exportMenu} role="menu" aria-label="Export options">
+              <button
+                type="button"
+                role="menuitem"
+                className={s.exportMenuItem}
+                onClick={() => handleExport('csv')}
+                disabled={isExporting}
+              >
+                Export CSV
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={s.exportMenuItem}
+                onClick={() => handleExport('json')}
+                disabled={isExporting}
+              >
+                Export JSON
+              </button>
+            </div>
+          )}
+        </div>
       </div>
-      <Pagination page={page} total={total} limit={limit}
-        onPrev={() => setPage((p) => p - 1)}
-        onNext={() => setPage((p) => p + 1)}
-      />
+
+      {exportError ? <p className={s.errorText}>{exportError}</p> : null}
+
+      {!subscribers.length ? (
+        <p className={s.empty}>No subscribers yet</p>
+      ) : (
+        <>
+          <div className={s.tableWrapper}>
+            <table className={s.table}>
+              <thead className={s.thead}>
+                <tr>
+                  <th>Email</th>
+                  <th>Subscribed</th>
+                </tr>
+              </thead>
+              <tbody className={s.tbody}>
+                {subscribers.map((sub) => (
+                  <tr key={sub._id}>
+                    <td>{sub.email}</td>
+                    <td className={s.cellMono}>{new Date(sub.createdAt).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <Pagination page={page} total={total} limit={limit}
+            onPrev={() => setPage((p) => p - 1)}
+            onNext={() => setPage((p) => p + 1)}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/client/src/Pages/AdminDashboard/AdminDashboard.module.scss
+++ b/client/src/Pages/AdminDashboard/AdminDashboard.module.scss
@@ -265,3 +265,72 @@ $lime-dim: #84cc16;
     cursor: not-allowed;
   }
 }
+
+.exportRow {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem 1.25rem 0;
+}
+
+.exportWrap {
+  position: relative;
+}
+
+.exportBtn {
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: $text-main;
+  background-color: transparent;
+  border: 1px solid $border;
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: #52525b;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.exportMenu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 170px;
+  border: 1px solid $border;
+  background-color: $bg-surface;
+  border-radius: 8px;
+  overflow: hidden;
+  z-index: 20;
+}
+
+.exportMenuItem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  color: $text-main;
+  border: none;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.errorText {
+  color: #fda4af;
+  font-size: 0.82rem;
+  margin: 0.75rem 1.25rem 0;
+}

--- a/client/src/Pages/AdminDashboard/AdminDashboard.test.jsx
+++ b/client/src/Pages/AdminDashboard/AdminDashboard.test.jsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminDashboard from './AdminDashboard';
+import {
+  exportNewsletterSubscribersCsv,
+  exportNewsletterSubscribersJson,
+} from '../../services/adminService';
+import downloadFile from '../../utils/downloadFile';
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector) => selector({ auth: { admin: { email: 'admin@devkofi.com' } } }),
+}));
+
+vi.mock('../../hooks/mutations/useLogoutAdmin', () => ({
+  default: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../hooks/queries/useContactMessages', () => ({
+  default: () => ({
+    isLoading: false,
+    data: {
+      data: {
+        data: {
+          messages: [],
+          page: 1,
+          total: 0,
+          limit: 20,
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock('../../hooks/queries/useNewsletterSubscribers', () => ({
+  default: () => ({
+    isLoading: false,
+    data: {
+      data: {
+        data: {
+          subscribers: [{ _id: '1', email: 'one@test.com', createdAt: '2026-04-22T10:30:00.000Z' }],
+          page: 1,
+          total: 1,
+          limit: 20,
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock('../../services/adminService', () => ({
+  exportNewsletterSubscribersCsv: vi.fn(),
+  exportNewsletterSubscribersJson: vi.fn(),
+}));
+
+vi.mock('../../utils/downloadFile', () => ({
+  default: vi.fn(),
+  getFilenameFromDisposition: vi.fn(() => 'newsletter-subscribers-2026-04-22.csv'),
+}));
+
+const renderComponent = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AdminDashboard />
+    </QueryClientProvider>
+  );
+};
+
+describe('AdminDashboard newsletter export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('triggers CSV download', async () => {
+    exportNewsletterSubscribersCsv.mockResolvedValue({
+      data: new Blob(['email,subscribedAt\n']),
+      headers: { 'content-disposition': 'attachment; filename="newsletter-subscribers-2026-04-22.csv"' },
+    });
+
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Newsletter Subscribers' }));
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Export CSV' }));
+
+    await waitFor(() => {
+      expect(exportNewsletterSubscribersCsv).toHaveBeenCalledTimes(1);
+      expect(downloadFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('triggers JSON download', async () => {
+    exportNewsletterSubscribersJson.mockResolvedValue({
+      data: new Blob(['[]']),
+      headers: { 'content-disposition': 'attachment; filename="newsletter-subscribers-2026-04-22.json"' },
+    });
+
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Newsletter Subscribers' }));
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Export JSON' }));
+
+    await waitFor(() => {
+      expect(exportNewsletterSubscribersJson).toHaveBeenCalledTimes(1);
+      expect(downloadFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows error state when export fails', async () => {
+    exportNewsletterSubscribersCsv.mockRejectedValue(new Error('boom'));
+
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Newsletter Subscribers' }));
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Export CSV' }));
+
+    expect(await screen.findByText('Export failed. Please try again.')).toBeTruthy();
+  });
+
+  it('shows loading label while exporting', async () => {
+    let resolveRequest;
+    const pendingPromise = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    exportNewsletterSubscribersCsv.mockReturnValue(pendingPromise);
+
+    renderComponent();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'Newsletter Subscribers' }));
+    await user.click(screen.getByRole('button', { name: 'Export' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Export CSV' }));
+
+    expect(screen.getByRole('button', { name: 'Exporting...' }).disabled).toBe(true);
+
+    resolveRequest({
+      data: new Blob(['email,subscribedAt\n']),
+      headers: { 'content-disposition': 'attachment; filename="newsletter-subscribers-2026-04-22.csv"' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Export' })).toBeTruthy();
+    });
+  });
+});

--- a/client/src/services/adminService.js
+++ b/client/src/services/adminService.js
@@ -14,3 +14,9 @@ export const getContactMessages = (page = 1, limit = 20) =>
 
 export const getNewsletterSubscribers = (page = 1, limit = 20) =>
   api.get('/api/admin/newsletter-subscribers', { params: { page, limit } });
+
+export const exportNewsletterSubscribersCsv = () =>
+  api.get('/api/admin/newsletter/export/csv', { responseType: 'blob' });
+
+export const exportNewsletterSubscribersJson = () =>
+  api.get('/api/admin/newsletter/export/json', { responseType: 'blob' });

--- a/client/src/utils/downloadFile.js
+++ b/client/src/utils/downloadFile.js
@@ -1,0 +1,24 @@
+export const getFilenameFromDisposition = (contentDisposition, fallbackName) => {
+  if (!contentDisposition) return fallbackName;
+
+  const utfMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utfMatch?.[1]) {
+    return decodeURIComponent(utfMatch[1]).replace(/['"]/g, '');
+  }
+
+  const match = contentDisposition.match(/filename\s*=\s*"?([^";]+)"?/i);
+  return match?.[1] || fallbackName;
+};
+
+const downloadFile = ({ blob, filename }) => {
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.URL.revokeObjectURL(objectUrl);
+};
+
+export default downloadFile;

--- a/server/controllers/adminDashboardController.js
+++ b/server/controllers/adminDashboardController.js
@@ -8,6 +8,25 @@ const parsePagination = (query) => {
   return { page, limit, skip };
 };
 
+const toExportRows = (subscribers = []) =>
+  subscribers.map((subscriber) => ({
+    email: subscriber.email,
+    subscribedAt: new Date(subscriber.createdAt).toISOString(),
+  }));
+
+const getExportFilename = (extension) => {
+  const date = new Date().toISOString().slice(0, 10);
+  return `newsletter-subscribers-${date}.${extension}`;
+};
+
+const escapeCsvValue = (value) => {
+  const normalized = String(value ?? '');
+  if (!/[",\n]/.test(normalized)) {
+    return normalized;
+  }
+  return `"${normalized.replace(/"/g, '""')}"`;
+};
+
 const getContactMessages = async (req, res) => {
   const { page, limit, skip } = parsePagination(req.query);
 
@@ -36,4 +55,35 @@ const getNewsletterSubscribers = async (req, res) => {
   });
 };
 
-module.exports = { getContactMessages, getNewsletterSubscribers };
+const exportNewsletterSubscribersJson = async (req, res) => {
+  const subscribers = await NewsletterSubscriber.find().sort({ createdAt: -1 });
+  const rows = toExportRows(subscribers);
+  const filename = getExportFilename('json');
+
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+  return res.status(200).send(JSON.stringify(rows, null, 2));
+};
+
+const exportNewsletterSubscribersCsv = async (req, res) => {
+  const subscribers = await NewsletterSubscriber.find().sort({ createdAt: -1 });
+  const rows = toExportRows(subscribers);
+  const filename = getExportFilename('csv');
+
+  const header = 'email,subscribedAt';
+  const lines = rows.map((row) => `${escapeCsvValue(row.email)},${escapeCsvValue(row.subscribedAt)}`);
+  const csv = `${header}\n${lines.join('\n')}${lines.length ? '\n' : ''}`;
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+  return res.status(200).send(csv);
+};
+
+module.exports = {
+  getContactMessages,
+  getNewsletterSubscribers,
+  exportNewsletterSubscribersJson,
+  exportNewsletterSubscribersCsv,
+};

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
 const { loginAdmin, logoutAdmin, getAdminSession } = require('../controllers/adminAuthController');
-const { getContactMessages, getNewsletterSubscribers } = require('../controllers/adminDashboardController');
+const {
+  getContactMessages,
+  getNewsletterSubscribers,
+  exportNewsletterSubscribersJson,
+  exportNewsletterSubscribersCsv,
+} = require('../controllers/adminDashboardController');
 const requireAdminAuth = require('../middleware/requireAdminAuth');
 const { loginRateLimit } = require('../config/env');
 
@@ -20,5 +25,7 @@ router.post('/auth/logout', logoutAdmin);
 router.get('/auth/me', requireAdminAuth, getAdminSession);
 router.get('/contact-messages', requireAdminAuth, getContactMessages);
 router.get('/newsletter-subscribers', requireAdminAuth, getNewsletterSubscribers);
+router.get('/newsletter/export/csv', requireAdminAuth, exportNewsletterSubscribersCsv);
+router.get('/newsletter/export/json', requireAdminAuth, exportNewsletterSubscribersJson);
 
 module.exports = router;

--- a/server/tests/admin.test.js
+++ b/server/tests/admin.test.js
@@ -25,13 +25,19 @@ beforeAll(async () => {
     subject: 'Hello',
     message: 'Test message',
   });
-  await NewsletterSubscriber.create({ email: 'subscriber@test.com' });
+
+  await NewsletterSubscriber.insertMany([
+    { email: 'older-subscriber@test.com', createdAt: new Date('2026-01-10T00:00:00.000Z') },
+    { email: 'new-subscriber@test.com', createdAt: new Date('2026-04-22T10:30:00.000Z') },
+  ]);
 });
 
 afterAll(async () => {
   await Admin.deleteMany({ email: TEST_EMAIL });
   await ContactMessage.deleteMany({ email: 'alice@test.com' });
-  await NewsletterSubscriber.deleteMany({ email: 'subscriber@test.com' });
+  await NewsletterSubscriber.deleteMany({
+    email: { $in: ['older-subscriber@test.com', 'new-subscriber@test.com'] },
+  });
   await mongoose.disconnect();
 });
 
@@ -153,6 +159,87 @@ describe('GET /api/admin/newsletter-subscribers', () => {
   it('returns 401 when unauthenticated', async () => {
     const res = await request(app).get('/api/admin/newsletter-subscribers');
     expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/admin/newsletter/export/csv', () => {
+  it('returns csv file for authenticated admin', async () => {
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get('/api/admin/newsletter/export/csv')
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/csv');
+    expect(res.headers['content-disposition']).toContain('.csv');
+    expect(res.text).toContain('email,subscribedAt');
+
+    const lines = res.text.trim().split('\n');
+    expect(lines[1]).toContain('new-subscriber@test.com');
+    expect(lines[2]).toContain('older-subscriber@test.com');
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/api/admin/newsletter/export/csv');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns headers only when list is empty', async () => {
+    await NewsletterSubscriber.deleteMany({});
+
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get('/api/admin/newsletter/export/csv')
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('email,subscribedAt\n');
+
+    await NewsletterSubscriber.insertMany([
+      { email: 'older-subscriber@test.com', createdAt: new Date('2026-01-10T00:00:00.000Z') },
+      { email: 'new-subscriber@test.com', createdAt: new Date('2026-04-22T10:30:00.000Z') },
+    ]);
+  });
+});
+
+describe('GET /api/admin/newsletter/export/json', () => {
+  it('returns json file for authenticated admin', async () => {
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get('/api/admin/newsletter/export/json')
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.headers['content-disposition']).toContain('.json');
+
+    const payload = JSON.parse(res.text);
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload[0]).toHaveProperty('email', 'new-subscriber@test.com');
+    expect(payload[0]).toHaveProperty('subscribedAt', '2026-04-22T10:30:00.000Z');
+    expect(payload[1]).toHaveProperty('email', 'older-subscriber@test.com');
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await request(app).get('/api/admin/newsletter/export/json');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty array when list is empty', async () => {
+    await NewsletterSubscriber.deleteMany({});
+
+    const cookie = await getAuthCookie();
+    const res = await request(app)
+      .get('/api/admin/newsletter/export/json')
+      .set('Cookie', cookie);
+
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.text)).toEqual([]);
+
+    await NewsletterSubscriber.insertMany([
+      { email: 'older-subscriber@test.com', createdAt: new Date('2026-01-10T00:00:00.000Z') },
+      { email: 'new-subscriber@test.com', createdAt: new Date('2026-04-22T10:30:00.000Z') },
+    ]);
   });
 });
 


### PR DESCRIPTION
### Motivation

- Provide admins a way to export newsletter subscribers from the dashboard in CSV and JSON formats with consistent fields and server-side filenames.
- Ensure exports are protected by admin auth and handle empty lists, loading and error states predictably.

### Description

- Implemented server-side export helpers and endpoints by adding `toExportRows`, `escapeCsvValue`, `getExportFilename`, and routes `GET /api/admin/newsletter/export/csv` and `GET /api/admin/newsletter/export/json` in `server/controllers/adminDashboardController.js` and `server/routes/adminRoutes.js`.
- Added CSV and JSON export behavior that sorts by `createdAt DESC`, returns `subscribedAt` as ISO timestamps, sets proper `Content-Type` and `Content-Disposition` headers, and safely escapes CSV values.
- Added frontend support with `exportNewsletterSubscribersCsv` and `exportNewsletterSubscribersJson` in `client/src/services/adminService.js`, a `downloadFile` utility and `getFilenameFromDisposition` in `client/src/utils/downloadFile.js`, and UI controls/state in `client/src/Pages/AdminDashboard/AdminDashboard.jsx` plus styles in `AdminDashboard.module.scss` to expose an export dropdown with loading/error handling.
- Added automated tests: backend Jest additions in `server/tests/admin.test.js` for CSV/JSON exports (auth, headers, order, empty behavior) and frontend Vitest tests in `client/src/Pages/AdminDashboard/AdminDashboard.test.jsx` to mock service calls and assert download/error/loading flows, and included the full implementation plan `/_plan/newsletter-export-plan.md`.

### Testing

- Ran backend Jest tests in `server/tests/admin.test.js` which cover authenticated/unauthenticated access, response headers, CSV content ordering, JSON payload shape, and empty-list behavior, and they passed.
- Ran frontend Vitest tests in `client/src/Pages/AdminDashboard/AdminDashboard.test.jsx` which mock `adminService` and `downloadFile` to validate UI interactions, download triggers, loading label, and error display, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9539257a88330b35431d1cfc8abd9)