### PR TITLE
Align pricing section with AI engineering support flow

### DIFF
--- a/client/src/components/Pricing/Pricing.jsx
+++ b/client/src/components/Pricing/Pricing.jsx
@@ -97,10 +97,7 @@ const Pricing = () => {
     }));
   }, [pricing]);
 
-  const featuredPlan = plans.find((p) => p.isPopular);
-  const otherPlans = plans.filter((p) => !p.isPopular);
-
-  const headerTitle = "Mentorship Plans";
+  const headerTitle = "Choose Your AI Engineering Support Level";
   const headerSubtitle =
     pricing?.program?.subtitle ||
     "Choose your mentorship depth and apply to start building with AI-powered MERN workflows.";
@@ -113,7 +110,7 @@ const Pricing = () => {
     const features = Array.isArray(plan?.includes) ? plan.includes : [];
 
     const ctaLabel = plan?.cta?.label || "Get Started";
-    const ctaRoute = "/contact";
+    const ctaRoute = plan?.cta?.route || "/contact";
 
     const cardClass = [
       "pricing-card",
@@ -177,7 +174,7 @@ const Pricing = () => {
           ))}
         </ul>
 
-        {isFeatured && whoItsFor.length > 0 && (
+        {whoItsFor.length > 0 && (
           <div className="card-who">
             <p className="card-who__label">Who it's for</p>
             <ul className="card-who__list">
@@ -292,10 +289,7 @@ const Pricing = () => {
           whileInView="visible"
           viewport={{ once: true, amount: 0.15 }}
         >
-          {featuredPlan && renderCard(featuredPlan, true)}
-          <div className="pricing-supporting">
-            {otherPlans.map((plan) => renderCard(plan))}
-          </div>
+          {plans.map((plan) => renderCard(plan, plan.isPopular))}
         </motion.div>
       )}
 

--- a/client/src/components/Pricing/pricing.styles.scss
+++ b/client/src/components/Pricing/pricing.styles.scss
@@ -85,17 +85,12 @@ $text-muted: #71717a;
   line-height: 1.4;
 }
 
-// ── Layout: Asymmetric ──────────────────────────────────────────────────
+// ── Layout ───────────────────────────────────────────────────────────────
 .pricing-layout {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1.25rem;
-}
-
-.pricing-supporting {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.25rem;
+  align-items: stretch;
 }
 
 // ── Card ─────────────────────────────────────────────────────────────────
@@ -122,8 +117,12 @@ $text-muted: #71717a;
 }
 
 .pricing-card.is-featured {
-  border-color: rgba($primary, 0.2);
-  background: rgba($primary, 0.02);
+  border-color: rgba($primary, 0.28);
+  background: linear-gradient(
+    180deg,
+    rgba($primary, 0.055),
+    rgba(255, 255, 255, 0.025)
+  );
   box-shadow: 0 16px 48px -12px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.05);
 
@@ -185,9 +184,9 @@ $text-muted: #71717a;
 
 .card-description {
   margin: 0;
-  color: #a1a1aa;
-  line-height: 1.6;
-  font-size: 0.88rem;
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.65;
+  font-size: 0.92rem;
 }
 
 // ── Features list ────────────────────────────────────────────────────────
@@ -205,7 +204,7 @@ $text-muted: #71717a;
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
-  color: #d4d4d8;
+  color: rgba(255, 255, 255, 0.82);
   font-size: 0.88rem;
   line-height: 1.5;
 
@@ -339,7 +338,7 @@ $text-muted: #71717a;
 .card-note {
   margin: 0.75rem 0 0;
   font-size: 0.72rem;
-  color: $text-muted;
+  color: rgba(255, 255, 255, 0.58);
   text-align: center;
 }
 
@@ -457,28 +456,18 @@ $text-muted: #71717a;
 
 // ── Responsive ───────────────────────────────────────────────────────────
 @media (min-width: 768px) {
-  .pricing-skeleton-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .pricing-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .pricing-supporting {
+  .pricing-skeleton-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1180px) {
   .pricing-layout {
-    grid-template-columns: 1.2fr 0.8fr;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1.5rem;
-    align-items: start;
-  }
-
-  .pricing-supporting {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-  }
-
-  .pricing-card.is-featured {
-    padding: 2.25rem;
   }
 }

--- a/server/data/pricingData.json
+++ b/server/data/pricingData.json
@@ -2,11 +2,11 @@
   "program": {
     "name": "DevKofi AI-Powered MERN Stack Mentorship",
     "slug": "devkofi-ai-powered-mern-mentorship",
-    "subtitle": "Engineering-first mentorship to help you ship production MERN apps with AI integrated across planning, coding, debugging, testing, and deployment.",
+    "subtitle": "Choose the level of engineering support you need to plan, build, debug, test, and ship production-grade MERN applications with practical AI workflows.",
     "promise": "Learn how real engineers use AI as a multiplier while keeping architecture, code quality, and shipping discipline high.",
     "guarantee": {
-      "title": "14-day confidence guarantee",
-      "details": "If it’s not the right fit in your first 14 days, you can request a refund."
+      "title": "14-day fit guarantee",
+      "details": "If the program is not the right fit within your first 14 days, you can request a refund."
     }
   },
   "ui": {
@@ -19,7 +19,7 @@
       "id": "plan_standard",
       "slug": "standard",
       "title": "Standard",
-      "tagline": "Structured mentorship for consistent AI-powered MERN execution.",
+      "tagline": "Structured guidance for developers building real MERN projects with AI-assisted workflows.",
       "badge": null,
       "pricing": {
         "amount": 900,
@@ -38,11 +38,11 @@
         "type": "enroll",
         "route": "/join/standard"
       },
-      "summary": "Build production-grade MERN projects while learning practical AI workflow integration.",
+      "summary": "Best for developers who want weekly guidance, practical accountability, and a clear path to shipping production-ready MERN projects with AI integrated into the workflow.",
       "whoItsFor": [
-        "Developers transitioning from tutorials to shipping real apps",
-        "Junior-to-mid engineers needing workflow discipline",
-        "Founders building product MVPs with MERN"
+        "Developers building serious portfolio projects",
+        "Junior-to-mid engineers improving full-stack execution",
+        "Builders who need structure, direction, and accountability"
       ],
       "outcomes": [
         "Plan features and scope work with AI support",
@@ -51,8 +51,9 @@
       ],
       "includes": [
         "Weekly mentorship guidance",
-        "AI workflow training for planning → shipping",
-        "Project-based path with production constraints",
+        "AI workflow training from planning to shipping",
+        "Project-based roadmap with real production constraints",
+        "Code review support for key milestones",
         "Community support and accountability check-ins"
       ],
       "accountability": {
@@ -73,7 +74,7 @@
       },
       "applicationRequired": true,
       "onboardingRequired": true,
-      "recommendedFor": "Developers who need structure and practical execution support",
+      "recommendedFor": "Developers who want structure, accountability, and practical AI-powered MERN execution",
       "deliveryFormat": "Mentorship + async support",
       "aiWorkflowCoverage": "Core",
       "reviewLevel": "Guided"
@@ -82,7 +83,7 @@
       "id": "plan_pro",
       "slug": "pro",
       "title": "Pro",
-      "tagline": "High-accountability mentorship with deeper code and architecture feedback.",
+      "tagline": "High-accountability engineering support for builders shipping serious apps faster.",
       "badge": "Most Popular",
       "pricing": {
         "amount": 1800,
@@ -101,11 +102,11 @@
         "type": "enroll",
         "route": "/join/pro"
       },
-      "summary": "Everything in Standard plus faster support, deeper review loops, and direct architecture mentoring.",
+      "summary": "Best for builders who want deeper technical review, faster feedback loops, architecture support, and closer guidance while shipping a serious product or advanced portfolio project.",
       "whoItsFor": [
         "Engineers shipping serious portfolio or startup work",
-        "Developers who need strong external accountability",
-        "Builders preparing for technical interviews or product launch"
+        "Developers preparing for technical interviews or product launches",
+        "Builders who want stronger external accountability"
       ],
       "outcomes": [
         "Ship faster with fewer regressions",
@@ -116,7 +117,9 @@
         "Everything in Standard",
         "Deeper code reviews and refactor feedback",
         "Architecture decision support",
-        "Priority support and tighter accountability cadence"
+        "Priority feedback and tighter accountability cadence",
+        "Launch, deployment, and debugging support",
+        "Direct support for production-level implementation decisions"
       ],
       "accountability": {
         "level": "high-touch",
@@ -136,7 +139,7 @@
       },
       "applicationRequired": true,
       "onboardingRequired": true,
-      "recommendedFor": "Developers and founders who need high-accountability shipping support",
+      "recommendedFor": "Developers and founders who want deeper review, faster feedback, and production-level support",
       "deliveryFormat": "Direct mentorship + faster feedback",
       "aiWorkflowCoverage": "Advanced",
       "reviewLevel": "Deep"
@@ -145,7 +148,7 @@
       "id": "plan_team",
       "slug": "team",
       "title": "Team / Enterprise",
-      "tagline": "AI-powered MERN workflow training for teams shipping production software.",
+      "tagline": "Practical AI-assisted engineering workflow training for teams.",
       "badge": null,
       "pricing": {
         "amount": 5000,
@@ -164,11 +167,11 @@
         "type": "request",
         "route": "/enterprise"
       },
-      "summary": "Upskill your team with practical AI-enhanced MERN engineering systems and delivery discipline.",
+      "summary": "Best for teams that want practical AI-assisted engineering workflows, shared development standards, and implementation support across real projects.",
       "whoItsFor": [
         "Startup teams shipping features weekly",
-        "Teams needing better code review and debugging practices",
-        "Engineering teams adopting AI safely"
+        "Engineering teams adopting AI-assisted workflows",
+        "Teams needing stronger planning, review, and delivery systems"
       ],
       "outcomes": [
         "Higher code quality and review standards",
@@ -177,9 +180,11 @@
       ],
       "includes": [
         "Discovery and skill-gap assessment",
-        "Team workflow coaching and standards",
+        "Team workflow coaching and engineering standards",
         "Practical AI-assisted planning and delivery sessions",
-        "Implementation support for team-specific roadmaps"
+        "Implementation support for team-specific roadmaps",
+        "Code review systems and delivery process improvements",
+        "Custom training for Claude Code, Codex, and agentic workflows"
       ],
       "accountability": {
         "level": "enterprise",
@@ -199,7 +204,7 @@
       },
       "applicationRequired": true,
       "onboardingRequired": false,
-      "recommendedFor": "Teams that want better engineering output with AI-enabled workflows",
+      "recommendedFor": "Teams that want practical AI-assisted engineering systems and stronger delivery discipline",
       "deliveryFormat": "Team workshop + ongoing advisory",
       "aiWorkflowCoverage": "Team-wide",
       "reviewLevel": "Org"


### PR DESCRIPTION
### Motivation
- Update the pricing content to reflect DevKofi's AI-powered engineering execution story instead of a generic "Mentorship Plans" framing.
- Preserve the desired linear user journey (`Standard → Pro → Team`) while keeping `Pro` visually highlighted but not rendered first.
- Improve readability, CTA routing, and responsive card layout so the UI matches the program flow and backend plan configuration.

### Description
- Updated program-level and plan copy in `server/data/pricingData.json` (program `subtitle`, `guarantee.title`/`guarantee.details`, and `tagline`, `summary`, `whoItsFor`, `includes`, and `recommendedFor` for `standard`, `pro`, and `team`).
- Changed the header in `client/src/components/Pricing/Pricing.jsx` to `const headerTitle = "Choose Your AI Engineering Support Level"`, made CTA use `plan?.cta?.route || "/contact"`, and enabled `Who it's for` for all plans by removing the `isFeatured` guard while keeping support badges scoped to featured plans.
- Replaced the `featuredPlan` / `otherPlans` rendering with a single ordered render `plans.map((plan) => renderCard(plan, plan.isPopular))` so UI rendering preserves JSON order while `isPopular` still controls visual highlight.
- Updated `client/src/components/Pricing/pricing.styles.scss` to remove the asymmetric supporting-column layout, implement a responsive 1 / 2 / 3 column progression (`mobile → 2-col @min-width:768px → 3-col @min-width:1180px`), adjust `.pricing-card.is-featured` to highlight via border/background (no oversized padding), and improve readability by brightening `.card-description`, `.card-features li`, and `.card-note` colors.

### Testing
- Ran `npm install` at project root and it completed successfully without blocking errors.
- Built the client with `npm run build` in `client/` and the production build completed successfully (Vite reported Sass `@import` deprecation and large-chunk warnings but there were no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec167c1cb883308f9d991a931d31ec)